### PR TITLE
REPL: hide password if supported by console

### DIFF
--- a/src/main/scala/org/codeoverflow/chatoverflow/ChatOverflow.scala
+++ b/src/main/scala/org/codeoverflow/chatoverflow/ChatOverflow.scala
@@ -61,7 +61,10 @@ class ChatOverflow(val pluginFolderPath: String,
   }
 
   private def askForPassword(): Unit = {
-    val password = scala.io.StdIn.readLine("Please enter password > ").toCharArray
+    val password = if (System.console() != null)
+        System.console().readPassword("Please enter password (Input hidden) > ")
+      else
+        scala.io.StdIn.readLine("Please enter password (Input NOT hidden) > ").toCharArray
     credentialsService.setPassword(password)
   }
 


### PR DESCRIPTION
Hides password on supported terminals like the windows cmd.
On unsupported terminals like in IntelliJ it falls back to normal reading.