### PR TITLE
Automatically create bootstrap/src/main/resources if missing

### DIFF
--- a/project/BootstrapUtility.scala
+++ b/project/BootstrapUtility.scala
@@ -43,6 +43,12 @@ object BootstrapUtility {
       </dependencies>
 
     logger info "Saving dependency XML now."
+
+    // Create directory if not existent, otherwise saving will fail.
+    if (new File(dependencyXMLFileName).getParentFile.mkdir()) {
+      logger info "Created directory bootstrap/src/main/resources"
+    }
+
     XML.save(dependencyXMLFileName, xml)
     logger info "Finished saving XML file."
   }


### PR DESCRIPTION
#10 removed bootstrap/src/main/resources/dependencies.xml from the git repo. The directory has to be created inorder to be able to save the dependencies xml file, so the directory has to be created if missing.