### PR TITLE
Create config dir, if it isn't existent in main framework instead of Bootstrap Launcher

### DIFF
--- a/bootstrap/src/main/scala/Bootstrap.scala
+++ b/bootstrap/src/main/scala/Bootstrap.scala
@@ -34,11 +34,6 @@ object Bootstrap {
         if (javaPath.isDefined) {
           println("Found java installation. Starting ChatOverflow...")
 
-          // Create config folder, if not existent
-          if (!new File("config/").exists()) {
-            new File("config/").mkdir()
-          }
-
           // Start chat overflow!
           val process = new java.lang.ProcessBuilder(javaPath.get, "-cp", s"bin/*${File.pathSeparator}lib/*", chatOverflowMainClass)
             .inheritIO().start()

--- a/src/main/scala/org/codeoverflow/chatoverflow/configuration/ConfigurationService.scala
+++ b/src/main/scala/org/codeoverflow/chatoverflow/configuration/ConfigurationService.scala
@@ -153,6 +153,12 @@ class ConfigurationService(val configFilePath: String) extends WithLogger {
     * Saves the xml content to the config xml.
     */
   private def saveXML(xmlContent: Node): Unit = {
+    // Create config folder, if not existent
+    val dir = new File(configFilePath).getParentFile
+    if(!dir.exists()) {
+      dir.mkdir()
+    }
+
     val writer = new PrintWriter(configFilePath)
     writer.print(new PrettyPrinter(120, 2).format(xmlContent))
     writer.close()


### PR DESCRIPTION
On the first start the default config should be saved, which fails if the folder doesn't exist. This creates a problem when you try to login to the gui. The framework can't be loaded because the config with plugins and connectors don't exist and you won't be able to login, until you create the config directory and restart.

A check for the config dir was in the Bootstrap Launcher, but when you run Chat Overflow in IntelliJ that check isn't working. So I added that check in the main framework.