### PR TITLE
Add gui to the build process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ project/plugins/project/
 
 # Plugin Data
 data/
+
+# Built gui
+/src/main/resources/chatoverflow-gui

--- a/.idea/runConfigurations/Build_GUI__sbt_gui_.xml
+++ b/.idea/runConfigurations/Build_GUI__sbt_gui_.xml
@@ -1,0 +1,11 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Build GUI (sbt gui)" type="SbtRunConfiguration" factoryName="sbt Task">
+    <setting name="tasks" value="gui" />
+    <setting name="vmparams" value="-Xms512M -Xmx1024M -Xss1M -XX:+CMSClassUnloadingEnabled" />
+    <setting name="workingDir" value="$PROJECT_DIR$" />
+    <setting name="useSbtShell" value="false" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.idea/runConfigurations/_Advanced__Full_Reload_and_Run_ChatOverflow.xml
+++ b/.idea/runConfigurations/_Advanced__Full_Reload_and_Run_ChatOverflow.xml
@@ -11,6 +11,7 @@
     <method v="2">
       <option name="RunConfigurationTask" enabled="true" run_configuration_name="Clean (sbt clean)" run_configuration_type="SbtRunConfiguration" />
       <option name="Make" enabled="true" />
+      <option name="RunConfigurationTask" enabled="true" run_configuration_name="Build GUI (sbt gui)" run_configuration_type="SbtRunConfiguration" />
       <option name="RunConfigurationTask" enabled="true" run_configuration_name="Fetch plugins (sbt fetch)" run_configuration_type="SbtRunConfiguration" />
       <option name="RunConfigurationTask" enabled="true" run_configuration_name="Reload (sbt reload)" run_configuration_type="SbtRunConfiguration" />
       <option name="RunConfigurationTask" enabled="true" run_configuration_name="List plugin versions (sbt version)" run_configuration_type="SbtRunConfiguration" />

--- a/.idea/runConfigurations/_Deploy__Generate_Bootstrap_Launcher_and_deploy.xml
+++ b/.idea/runConfigurations/_Deploy__Generate_Bootstrap_Launcher_and_deploy.xml
@@ -5,6 +5,7 @@
     <method v="2">
       <option name="RunConfigurationTask" enabled="true" run_configuration_name="Clean (sbt clean)" run_configuration_type="SbtRunConfiguration" />
       <option name="Make" enabled="true" />
+      <option name="RunConfigurationTask" enabled="true" run_configuration_name="Build GUI (sbt gui)" run_configuration_type="SbtRunConfiguration" />
       <option name="RunConfigurationTask" enabled="true" run_configuration_name="Package and copy plugins (sbt package copy)" run_configuration_type="SbtRunConfiguration" />
       <option name="RunConfigurationTask" enabled="true" run_configuration_name="Bootstrap Assembly (sbt bs assembly)" run_configuration_type="SbtRunConfiguration" />
       <option name="RunConfigurationTask" enabled="true" run_configuration_name="Deploy (sbt deploy)" run_configuration_type="SbtRunConfiguration" />

--- a/.idea/runConfigurations/_Simple__Rebuild_plugins_and_Run_ChatOverflow.xml
+++ b/.idea/runConfigurations/_Simple__Rebuild_plugins_and_Run_ChatOverflow.xml
@@ -10,7 +10,6 @@
     </extension>
     <method v="2">
       <option name="Make" enabled="true" />
-      <option name="RunConfigurationTask" enabled="true" run_configuration_name="Build GUI (sbt gui)" run_configuration_type="SbtRunConfiguration" />
       <option name="RunConfigurationTask" enabled="true" run_configuration_name="Package and copy plugins (sbt package copy)" run_configuration_type="SbtRunConfiguration" />
     </method>
   </configuration>

--- a/.idea/runConfigurations/_Simple__Rebuild_plugins_and_Run_ChatOverflow.xml
+++ b/.idea/runConfigurations/_Simple__Rebuild_plugins_and_Run_ChatOverflow.xml
@@ -10,6 +10,7 @@
     </extension>
     <method v="2">
       <option name="Make" enabled="true" />
+      <option name="RunConfigurationTask" enabled="true" run_configuration_name="Build GUI (sbt gui)" run_configuration_type="SbtRunConfiguration" />
       <option name="RunConfigurationTask" enabled="true" run_configuration_name="Package and copy plugins (sbt package copy)" run_configuration_type="SbtRunConfiguration" />
     </method>
   </configuration>

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 advanced_run:
 	sbt clean
 	sbt compile
+	sbt gui
 	sbt fetch
 	sbt reload
 	sbt version
@@ -10,11 +11,13 @@ advanced_run:
 
 simple_run:
 	sbt compile
+	sbt gui
 	sbt package copy
 
 bootstrap_deploy:
-	sbt compile
 	sbt clean
+	sbt compile
+	sbt gui
 	sbt package copy
 	sbt bs "project bootstrapProject" assembly
 	sbt deploy

--- a/project/BuildUtility.scala
+++ b/project/BuildUtility.scala
@@ -256,7 +256,7 @@ class BuildUtility(logger: ManagedLogger) {
 
       logger info "Installing GUI dependencies."
 
-      val exitCode = new ProcessBuilder("npm", "install")
+      val exitCode = new ProcessBuilder(getNpmCommand :+ "install": _*)
         .inheritIO()
         .directory(guiDir)
         .start()
@@ -293,7 +293,7 @@ class BuildUtility(logger: ManagedLogger) {
 
       logger info "Building GUI."
 
-      val buildExitCode = new ProcessBuilder("npm", "run", "build")
+      val buildExitCode = new ProcessBuilder(getNpmCommand :+ "run" :+ "build": _*)
         .inheritIO()
         .directory(guiDir)
         .start()
@@ -314,6 +314,14 @@ class BuildUtility(logger: ManagedLogger) {
     val inputs = recursiveFileListing(srcDir) + packageJson
 
     build(inputs).headOption
+  }
+
+  private def getNpmCommand: List[String] = {
+    if (System.getProperty("os.name").toLowerCase().contains("win")) {
+      List("cmd.exe", "/C", "npm")
+    } else {
+      List("npm")
+    }
   }
 
   /**

--- a/src/main/scala/org/codeoverflow/chatoverflow/ui/web/Server.scala
+++ b/src/main/scala/org/codeoverflow/chatoverflow/ui/web/Server.scala
@@ -1,7 +1,7 @@
 package org.codeoverflow.chatoverflow.ui.web
 
 import org.codeoverflow.chatoverflow.{ChatOverflow, WithLogger}
-import org.eclipse.jetty.servlet.ServletHandler.Default404Servlet
+import org.eclipse.jetty.util.resource.Resource
 import org.eclipse.jetty.webapp.WebAppContext
 import org.scalatra.servlet.ScalatraListener
 
@@ -17,9 +17,8 @@ class Server(val chatOverflow: ChatOverflow, val port: Int) extends WithLogger {
   private val context = new WebAppContext()
   context.setInitParameter("org.eclipse.jetty.servlet.Default.dirAllowed", "false")
   context setContextPath "/"
-  context.setResourceBase("/")
+  context.setBaseResource(Resource.newClassPathResource("/chatoverflow-gui/"))
   context.addEventListener(new ScalatraListener)
-  context.addServlet(classOf[Default404Servlet], "/")
 
   server.setHandler(context)
 


### PR DESCRIPTION
Adds a task to sbt to build the gui and add it to the classpath. Jetty then serves the gui right from the classpath/jar. Meant to be a transition til the gui is packaged as a electron app.

Currently the gui is included in the jar of the main framework when deployed. Do you rather want it to be in a seperate jar only for the gui or is it fine in the main jar?