### PR TITLE
Fix channel auto-formatting in TwitchChat

### DIFF
--- a/src/main/scala/org/codeoverflow/chatoverflow/requirement/service/twitch/chat/TwitchChatConnector.scala
+++ b/src/main/scala/org/codeoverflow/chatoverflow/requirement/service/twitch/chat/TwitchChatConnector.scala
@@ -30,27 +30,18 @@ class TwitchChatConnector(override val sourceIdentifier: String) extends Connect
   }
 
   def joinChannel(channel: String): Unit = {
-    val formattedChan = formatChannel(channel)
-    bot.send().joinChannel(formattedChan)
-    channels += formattedChan
+    bot.send().joinChannel(channel)
+    channels += channel
   }
 
   def sendChatMessage(channel: String, chatMessage: String): Unit = {
-    val formattedChan = formatChannel(channel)
-    if (!isJoined(formattedChan)) throw new IllegalArgumentException(s"you must join the '$channel' channel, before you can send messages to it")
-    bot.send().message(formattedChan, chatMessage)
+    if (!isJoined(channel)) throw new IllegalArgumentException(s"you must join the '$channel' channel, before you can send messages to it")
+    bot.send().message(channel, chatMessage)
   }
 
   override def getUniqueTypeString: String = this.getClass.getName
 
-  def isJoined(channel: String): Boolean = channels.contains(formatChannel(channel))
-
-  /**
-    * Ensures that the channel is in following format: "#lowercasename"
-    * @param chan the unmodified channel
-    * @return the channel in the correct format, changes nothing if already correct
-    */
-  private def formatChannel(chan: String): String = s"#${chan.stripPrefix("#").toLowerCase}"
+  def isJoined(channel: String): Boolean = channels.contains(channel)
 
   private def getConfig: Configuration = {
 
@@ -117,4 +108,15 @@ class TwitchChatConnector(override val sourceIdentifier: String) extends Connect
     bot.close()
     true
   }
+}
+
+object TwitchChatConnector {
+
+  /**
+    * Ensures that the channel is in following format: "#lowercasename"
+    *
+    * @param chan the unmodified channel
+    * @return the channel in the correct format, changes nothing if already correct
+    */
+  private[chat] def formatChannel(chan: String): String = s"#${chan.stripPrefix("#").toLowerCase}"
 }

--- a/src/main/scala/org/codeoverflow/chatoverflow/requirement/service/twitch/chat/impl/TwitchChatInputImpl.scala
+++ b/src/main/scala/org/codeoverflow/chatoverflow/requirement/service/twitch/chat/impl/TwitchChatInputImpl.scala
@@ -10,6 +10,7 @@ import org.codeoverflow.chatoverflow.api.io.input.chat._
 import org.codeoverflow.chatoverflow.registry.Impl
 import org.codeoverflow.chatoverflow.requirement.InputImpl
 import org.codeoverflow.chatoverflow.requirement.service.twitch.chat
+import org.codeoverflow.chatoverflow.requirement.service.twitch.chat.TwitchChatConnector
 import org.pircbotx.hooks.events.{MessageEvent, UnknownEvent}
 
 import scala.collection.JavaConverters._
@@ -101,7 +102,7 @@ class TwitchChatInputImpl extends InputImpl[chat.TwitchChatConnector] with Twitc
   override def registerPrivateMessageHandler(handler: Consumer[TwitchChatMessage]): Unit = privateMessageHandler += handler
 
   override def setChannel(channel: String): Unit = {
-    currentChannel = Some(channel.trim)
-    if (!sourceConnector.get.isJoined(channel.trim)) sourceConnector.get.joinChannel(channel.trim)
+    currentChannel = Some(TwitchChatConnector.formatChannel(channel.trim))
+    if (!sourceConnector.get.isJoined(currentChannel.get)) sourceConnector.get.joinChannel(currentChannel.get)
   }
 }

--- a/src/main/scala/org/codeoverflow/chatoverflow/requirement/service/twitch/chat/impl/TwitchChatOutputImpl.scala
+++ b/src/main/scala/org/codeoverflow/chatoverflow/requirement/service/twitch/chat/impl/TwitchChatOutputImpl.scala
@@ -5,6 +5,7 @@ import org.codeoverflow.chatoverflow.api.io.output.chat.TwitchChatOutput
 import org.codeoverflow.chatoverflow.registry.Impl
 import org.codeoverflow.chatoverflow.requirement.OutputImpl
 import org.codeoverflow.chatoverflow.requirement.service.twitch.chat
+import org.codeoverflow.chatoverflow.requirement.service.twitch.chat.TwitchChatConnector
 
 /**
   * This is the implementation of the twitch chat output, using the twitch connector.
@@ -24,7 +25,7 @@ class TwitchChatOutputImpl extends OutputImpl[chat.TwitchChatConnector] with Twi
   override def start(): Boolean = true
 
   override def setChannel(channel: String): Unit = {
-    currentChannel = Some(channel.trim)
-    if (!sourceConnector.get.isJoined(channel.trim)) sourceConnector.get.joinChannel(channel.trim)
+    currentChannel = Some(TwitchChatConnector.formatChannel(channel.trim))
+    if (!sourceConnector.get.isJoined(currentChannel.get)) sourceConnector.get.joinChannel(currentChannel.get)
   }
 }


### PR DESCRIPTION
I've seem to completely messed up #14, which auto-formatted the channel in the `TwitchChatConnector` but not in the In/Outputs.
In the `TwitchChatInput` the correct format is required, because it checks whether the channel of messages is the same as in the input, which fails if the wrong format is stored there.
Now I've just moved the formatting in the In/Outputs and from my testing it (currently) works.