### PR TITLE
Implement a real loop for plugins

### DIFF
--- a/src/main/scala/org/codeoverflow/chatoverflow/instance/PluginInstance.scala
+++ b/src/main/scala/org/codeoverflow/chatoverflow/instance/PluginInstance.scala
@@ -163,8 +163,14 @@ class PluginInstance(val instanceName: String, pluginType: PluginType) extends W
                   // Execute loop, if an interval is set
                   if (plugin.get.getLoopInterval > 0) {
                     while (!threadStopAfterNextIteration) {
+                      val startTime = System.currentTimeMillis()
+
                       plugin.get.loop()
-                      Thread.sleep(plugin.get.getLoopInterval)
+
+                      val execTime = System.currentTimeMillis() - startTime
+                      val sleepTime = plugin.get.getLoopInterval - execTime
+                      if (sleepTime > 0)
+                        Thread.sleep(sleepTime)
                     }
                   }
 


### PR DESCRIPTION
Fixes #26 
Heres my test code: 
```scala
import org.codeoverflow.chatoverflow.api.plugin.{PluginImpl, PluginManager}

class simpletestPlugin(manager: PluginManager) extends PluginImpl(manager) {
  loopInterval = 1000
  var startTime = 0L

  override def setup(): Unit = {
    startTime = System.currentTimeMillis()
    log("Started successfully!")
  }

  override def loop(): Unit = {
    val delta = System.currentTimeMillis() - startTime
    log(delta.toString)
    Thread.sleep(500) // fake execution time
  }

  override def shutdown(): Unit = {}
}

```