### PR TITLE
Fix Makefile indentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,5 +58,5 @@ git_pull:
 	cd ..
 	cd gui
 	git stash
-    git pull
-    git stash pop
+	git pull
+	git stash pop


### PR DESCRIPTION
The makefile was indented using spaces instead of tabs in the last two lines, causing problems with GNU make.