### PR TITLE
Disable GUI caching in jetty

### DIFF
--- a/src/main/scala/org/codeoverflow/chatoverflow/ui/web/Server.scala
+++ b/src/main/scala/org/codeoverflow/chatoverflow/ui/web/Server.scala
@@ -16,6 +16,7 @@ class Server(val chatOverflow: ChatOverflow, val port: Int) extends WithLogger {
   private val server = new org.eclipse.jetty.server.Server(port)
   private val context = new WebAppContext()
   context.setInitParameter("org.eclipse.jetty.servlet.Default.dirAllowed", "false")
+  context.setInitParameter("org.eclipse.jetty.servlet.Default.cacheControl", "no-cache,no-store")
   context setContextPath "/"
   context.setBaseResource(Resource.newClassPathResource("/chatoverflow-gui/"))
   context.addEventListener(new ScalatraListener)


### PR DESCRIPTION
Adds a cache-control header to each response made by jetty to disable caching.

Closes #67.