### PR TITLE
Only scan requirement package for classes with Impl annotation

### DIFF
--- a/src/main/scala/org/codeoverflow/chatoverflow/registry/TypeRegistry.scala
+++ b/src/main/scala/org/codeoverflow/chatoverflow/registry/TypeRegistry.scala
@@ -4,7 +4,7 @@ import org.codeoverflow.chatoverflow.WithLogger
 import org.codeoverflow.chatoverflow.connector.Connector
 import org.reflections.Reflections
 import org.reflections.scanners.{SubTypesScanner, TypeAnnotationsScanner}
-import org.reflections.util.{ClasspathHelper, ConfigurationBuilder}
+import org.reflections.util.{ClasspathHelper, ConfigurationBuilder, FilterBuilder}
 
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
@@ -55,6 +55,8 @@ class TypeRegistry(requirementPackage: String) extends WithLogger {
     // Use reflection magic to get all impl-annotated classes
     val reflections: Reflections = new Reflections(new ConfigurationBuilder()
       .setUrls(ClasspathHelper.forPackage(requirementPackage))
+      .filterInputsBy(new FilterBuilder()
+        .includePackage(requirementPackage))
       .setScanners(new SubTypesScanner(), new TypeAnnotationsScanner()))
     val classes = reflections.getTypesAnnotatedWith(classOf[Impl])
 


### PR DESCRIPTION
The annotation scanner tries to scan every single file on the classpath, including the gui. Obviously not all of this files are `*.class` files, which results in errors from the classloader. These errors alone make up about 1500 lines of log if enabled and is one of the main reasons why the log of MelanX was so big.
By only scanning the package of the requirements this issue is fixed and it's required anyway to fix #31 which is also done by this pr.