### PR TITLE
Pass functions to register method from inputs instead of methods

### DIFF
--- a/src/main/scala/org/codeoverflow/chatoverflow/requirement/service/serial/impl/SerialInputImpl.scala
+++ b/src/main/scala/org/codeoverflow/chatoverflow/requirement/service/serial/impl/SerialInputImpl.scala
@@ -12,8 +12,10 @@ import org.codeoverflow.chatoverflow.requirement.service.serial.SerialConnector
 @Impl(impl = classOf[SerialInput], connector = classOf[SerialConnector])
 class SerialInputImpl extends EventInputImpl[SerialEvent, SerialConnector] with SerialInput with WithLogger {
 
+  private val onInputFn = onInput _
+
   override def start(): Boolean = {
-    sourceConnector.get.addInputListener(onInput)
+    sourceConnector.get.addInputListener(onInputFn)
     true
   }
 
@@ -27,7 +29,7 @@ class SerialInputImpl extends EventInputImpl[SerialEvent, SerialConnector] with 
     * @return true if stopping was successful
     */
   override def stop(): Boolean = {
-    sourceConnector.get.removeInputListener(onInput)
+    sourceConnector.get.removeInputListener(onInputFn)
     true
   }
 }

--- a/src/main/scala/org/codeoverflow/chatoverflow/requirement/service/tipeeestream/impl/TipeestreamEventInputImpl.scala
+++ b/src/main/scala/org/codeoverflow/chatoverflow/requirement/service/tipeeestream/impl/TipeestreamEventInputImpl.scala
@@ -19,10 +19,14 @@ class TipeestreamEventInputImpl extends EventInputImpl[TipeeestreamEvent, Tipeee
   private val DATE_FORMATTER = new DateTimeFormatterBuilder()
     .parseCaseInsensitive().append(DateTimeFormatter.ISO_LOCAL_DATE_TIME).appendOffset("+HHMM", "Z").toFormatter
 
+  private val onFollowFn = onFollow _
+  private val onSubscriptionFn = onSubscription _
+  private val onDonationFn = onDonation _
+
   override def start(): Boolean = {
-    sourceConnector.get.addFollowEventListener(onFollow)
-    sourceConnector.get.addSubscriptionEventListener(onSubscription)
-    sourceConnector.get.addDonationEventListener(onDonation)
+    sourceConnector.get.addFollowEventListener(onFollowFn)
+    sourceConnector.get.addSubscriptionEventListener(onSubscriptionFn)
+    sourceConnector.get.addDonationEventListener(onDonationFn)
     true
   }
 
@@ -84,9 +88,9 @@ class TipeestreamEventInputImpl extends EventInputImpl[TipeeestreamEvent, Tipeee
   }
 
   override def stop(): Boolean = {
-    sourceConnector.get.removeFollowEventListener(onFollow)
-    sourceConnector.get.removeSubscriptionEventListener(onSubscription)
-    sourceConnector.get.removeDonationEventListener(onDonation)
+    sourceConnector.get.removeFollowEventListener(onFollowFn)
+    sourceConnector.get.removeSubscriptionEventListener(onSubscriptionFn)
+    sourceConnector.get.removeDonationEventListener(onDonationFn)
     true
   }
 }

--- a/src/main/scala/org/codeoverflow/chatoverflow/requirement/service/twitch/chat/impl/TwitchChatInputImpl.scala
+++ b/src/main/scala/org/codeoverflow/chatoverflow/requirement/service/twitch/chat/impl/TwitchChatInputImpl.scala
@@ -9,7 +9,7 @@ import org.codeoverflow.chatoverflow.api.io.dto.chat.{ChatEmoticon, TextChannel}
 import org.codeoverflow.chatoverflow.api.io.event.chat.twitch.{TwitchChatMessageReceiveEvent, TwitchEvent, TwitchPrivateChatMessageReceiveEvent}
 import org.codeoverflow.chatoverflow.api.io.input.chat._
 import org.codeoverflow.chatoverflow.registry.Impl
-import org.codeoverflow.chatoverflow.requirement.impl.{EventInputImpl, InputImpl}
+import org.codeoverflow.chatoverflow.requirement.impl.EventInputImpl
 import org.codeoverflow.chatoverflow.requirement.service.twitch.chat
 import org.codeoverflow.chatoverflow.requirement.service.twitch.chat.TwitchChatConnector
 import org.pircbotx.hooks.events.{MessageEvent, UnknownEvent}
@@ -31,9 +31,12 @@ class TwitchChatInputImpl extends EventInputImpl[TwitchEvent, chat.TwitchChatCon
 
   private var currentChannel: Option[String] = None
 
+  private val onMessageFn = onMessage _
+  private val onUnknownFn = onUnknown _
+
   override def start(): Boolean = {
-    sourceConnector.get.addMessageEventListener(onMessage)
-    sourceConnector.get.addUnknownEventListener(onUnknown)
+    sourceConnector.get.addMessageEventListener(onMessageFn)
+    sourceConnector.get.addUnknownEventListener(onUnknownFn)
     true
   }
 
@@ -105,8 +108,8 @@ class TwitchChatInputImpl extends EventInputImpl[TwitchEvent, chat.TwitchChatCon
     * @return true if stopping was successful
     */
   override def stop(): Boolean = {
-    sourceConnector.get.removeMessageEventListener(onMessage)
-    sourceConnector.get.removeUnknownEventListener(onUnknown)
+    sourceConnector.get.removeMessageEventListener(onMessageFn)
+    sourceConnector.get.removeUnknownEventListener(onUnknownFn)
     true
   }
 }


### PR DESCRIPTION
Finishes fix of #89.

The problem was that we passed methods to the register/unregister methods, which take functions. In these cases scala will convert the methods to anonymous functions e.g. in the TwitchChatInput start part `onMessage` will get changed to `x => onMessage(x)`. Because of this the function passed in the start method is not the **exact** same object as the one in the stop method, the handler of the input wasn't removed in the connector.

Note that I only have tested this with the twitch chat input, but the handler logic similar in all other connectors it should work there too.

In the future we probably want to generalize connectors that have event handlers with some trait. Then we could place a implicit identifier in the inputs and have the connector unregister all handlers that were registered with a identifier when the plugin stops. Thats a way cleaner solution, but will require more time, so this is just for the 2.1 hotfix.