### PR TITLE
Escape plugin names in plugins.sbt and generated source files

### DIFF
--- a/project/Plugin.scala
+++ b/project/Plugin.scala
@@ -12,8 +12,8 @@ import scala.xml.PrettyPrinter
   * @param name                      the name of the plugin
   */
 class Plugin(val pluginSourceDirectoryName: String, val name: String) {
-  val normalizedName: String = Plugin.toPluginPathName(name)
-  val pluginDirectoryPath: String = s"$pluginSourceDirectoryName/$normalizedName"
+  val normalizedName: String = Plugin.toNormalizedName(name)
+  val pluginDirectoryPath: String = s"$pluginSourceDirectoryName/${normalizedName.toLowerCase}"
 
   /**
     * Creates the plugin folder inside of a plugin source directory
@@ -147,7 +147,20 @@ object Plugin {
     pluginSourceFolder.exists() && pluginSourceFolder.isDirectory
   }
 
-  private def toPluginPathName(name: String) = name.replaceAll("[ -]", "").toLowerCase
+  private def toNormalizedName(name: String): String = {
+    if (name.isEmpty) {
+      return ""
+    }
+
+    val firstChar = name(0)
+
+    if (!Character.isJavaIdentifierStart(firstChar)) {
+      toNormalizedName(name.substring(1))
+    } else {
+      val rest = name.substring(1)
+      firstChar + rest.filter(Character.isJavaIdentifierPart)
+    }
+  }
 
   private def containsPluginXMLFile(directory: File): Boolean = {
     new File(s"$directory/src/main/resources/plugin.xml").exists()

--- a/project/SbtFile.scala
+++ b/project/SbtFile.scala
@@ -55,11 +55,11 @@ class SbtFile(var name: String, var version: String, var plugins: List[Plugin], 
     val sbtContent = new StringBuilder("// GENERATED FILE USING THE CHAT OVERFLOW PLUGIN FRAMEWORK\n")
 
     if (name != "") {
-      sbtContent append "\nname := \"%s\"".format(name)
+      sbtContent append "\nname := \"%s\"".format(name.replaceAll("\\", ""))
     }
 
     if (version != "") {
-      sbtContent append "\nversion := \"%s\"".format(version)
+      sbtContent append "\nversion := \"%s\"".format(version.replaceAll("\\", ""))
     }
 
     if (plugins.nonEmpty) {

--- a/project/SbtFile.scala
+++ b/project/SbtFile.scala
@@ -64,7 +64,7 @@ class SbtFile(var name: String, var version: String, var plugins: List[Plugin], 
 
     if (plugins.nonEmpty) {
       for (plugin <- plugins) {
-        var pluginLine = "\nlazy val %s = (project in file(\"%s\"))".format(plugin.normalizedName, plugin.pluginDirectoryPath)
+        var pluginLine = "\nlazy val `%s` = (project in file(\"%s\"))".format(plugin.normalizedName, plugin.pluginDirectoryPath)
 
         if (apiProjectPath != "") {
           pluginLine += ".dependsOn(apiProject)"
@@ -79,8 +79,8 @@ class SbtFile(var name: String, var version: String, var plugins: List[Plugin], 
     }
 
     if (defineRoot) {
-      var rootLine = "\n\nlazy val root = (project in file(\".\")).aggregate(apiProject,%s)"
-        .format(plugins.map(_.normalizedName).mkString(", "))
+      var rootLine = "\n\nlazy val root = (project in file(\".\")).aggregate(apiProject, %s)"
+        .format(plugins.map(p => s"`${p.normalizedName}`").mkString(", "))
 
       if (apiProjectPath != "") {
         rootLine += ".dependsOn(apiProject)"


### PR DESCRIPTION
Fixes #94 by escaping variable names in `plugins.sbt` and filtering out illegal characters for the generated class file.