### PR TITLE
Make the output of the requirement file generator determinable

### DIFF
--- a/project/APIUtility.scala
+++ b/project/APIUtility.scala
@@ -60,6 +60,7 @@ class APIUtility(logger: ManagedLogger) {
           }
         }
       }.filter(_.isDefined).map(_.get)
+        .sortBy(x => x.file.getAbsolutePath)
 
     RequirementsFile(new File(sourceDirectory, configurationFolder), "Input", filesWithRequirements.head).createFile()
     RequirementsFile(new File(sourceDirectory, configurationFolder), "Output", filesWithRequirements(1)).createFile()


### PR DESCRIPTION
When I recompile the api the order of the generated requirements almost always change. 
These changes can accidentally be committed like in https://github.com/codeoverflow-org/chatoverflow-api/commit/4bf446bc776906ca35840e180be65e8b413a54c1. There the requirement file of the inputs has changed, but those are just reorderings. 
A fix for this is to order all input files, which will always result in the same output.