### PR TITLE
Update run configurations to support IntelliJ 2019.2 and higher

### DIFF
--- a/.idea/runConfigurations/Bootstrap_Assembly__sbt_bs_assembly_.xml
+++ b/.idea/runConfigurations/Bootstrap_Assembly__sbt_bs_assembly_.xml
@@ -1,8 +1,18 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Bootstrap Assembly (sbt bs assembly)" type="SbtRunConfiguration" factoryName="sbt Task">
+    <!-- for IntelliJ < 2019.2-->
     <setting name="tasks" value="bs &quot;project bootstrapProject&quot; assembly" />
     <setting name="vmparams" value="-Xms512M -Xmx1024M -Xss1M -XX:+CMSClassUnloadingEnabled" />
     <setting name="workingDir" value="$PROJECT_DIR$" />
+    
+    <!-- for IntelliJ >= 2019.2 -->
+    <option name="allowRunningInParallel" value="false" />
+    <option name="tasks" value="bs &quot;project bootstrapProject&quot; assembly" />
+    <option name="useSbtShell" value="false" />
+    <option name="vmparams" value="-Xms512M -Xmx1024M -Xss1M -XX:+CMSClassUnloadingEnabled" />
+    <option name="workingDir" value="$PROJECT_DIR$" />
+
+    <!-- used by all IntelliJ versions -->
     <envs />
     <method />
   </configuration>

--- a/.idea/runConfigurations/Build_GUI__sbt_gui_.xml
+++ b/.idea/runConfigurations/Build_GUI__sbt_gui_.xml
@@ -1,9 +1,19 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Build GUI (sbt gui)" type="SbtRunConfiguration" factoryName="sbt Task">
+    <!-- for IntelliJ < 2019.2-->
     <setting name="tasks" value="gui" />
     <setting name="vmparams" value="-Xms512M -Xmx1024M -Xss1M -XX:+CMSClassUnloadingEnabled" />
     <setting name="workingDir" value="$PROJECT_DIR$" />
     <setting name="useSbtShell" value="false" />
+
+    <!-- for IntelliJ >= 2019.2 -->
+    <option name="allowRunningInParallel" value="false" />
+    <option name="tasks" value="gui" />
+    <option name="useSbtShell" value="false" />
+    <option name="vmparams" value="-Xms512M -Xmx1024M -Xss1M -XX:+CMSClassUnloadingEnabled" />
+    <option name="workingDir" value="$PROJECT_DIR$" />
+    
+    <!-- used by all IntelliJ versions -->
     <method v="2">
       <option name="Make" enabled="true" />
     </method>

--- a/.idea/runConfigurations/Clean__sbt_clean_.xml
+++ b/.idea/runConfigurations/Clean__sbt_clean_.xml
@@ -1,8 +1,18 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Clean (sbt clean)" type="SbtRunConfiguration" factoryName="sbt Task">
+    <!-- for IntelliJ < 2019.2-->
     <setting name="tasks" value="clean" />
     <setting name="vmparams" value="-Xms512M -Xmx1024M -Xss1M -XX:+CMSClassUnloadingEnabled" />
     <setting name="workingDir" value="$PROJECT_DIR$" />
+    
+    <!-- for IntelliJ >= 2019.2 -->
+    <option name="allowRunningInParallel" value="false" />
+    <option name="tasks" value="clean" />
+    <option name="useSbtShell" value="false" />
+    <option name="vmparams" value="-Xms512M -Xmx1024M -Xss1M -XX:+CMSClassUnloadingEnabled" />
+    <option name="workingDir" value="$PROJECT_DIR$" />
+
+    <!-- used by all IntelliJ versions -->
     <envs />
     <method />
   </configuration>

--- a/.idea/runConfigurations/Create_Plugin__sbt_create_fetch_reload_.xml
+++ b/.idea/runConfigurations/Create_Plugin__sbt_create_fetch_reload_.xml
@@ -1,9 +1,19 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Create Plugin (sbt create fetch reload)" type="SbtRunConfiguration" factoryName="sbt Task">
+    <!-- for IntelliJ < 2019.2-->
     <setting name="tasks" value="create fetch reload" />
     <setting name="vmparams" value="-Xms512M -Xmx1024M -Xss1M -XX:+CMSClassUnloadingEnabled" />
     <setting name="workingDir" value="$PROJECT_DIR$" />
     <setting name="useSbtShell" value="false" />
+
+    <!-- for IntelliJ >= 2019.2 -->
+    <option name="allowRunningInParallel" value="false" />
+    <option name="tasks" value="create fetch reload" />
+    <option name="useSbtShell" value="false" />
+    <option name="vmparams" value="-Xms512M -Xmx1024M -Xss1M -XX:+CMSClassUnloadingEnabled" />
+    <option name="workingDir" value="$PROJECT_DIR$" />
+
+    <!-- used by all IntelliJ versions -->
     <method v="2">
       <option name="Make" enabled="true" />
     </method>

--- a/.idea/runConfigurations/Deploy__sbt_deploy_.xml
+++ b/.idea/runConfigurations/Deploy__sbt_deploy_.xml
@@ -1,8 +1,18 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Deploy (sbt deploy)" type="SbtRunConfiguration" factoryName="sbt Task">
+    <!-- for IntelliJ < 2019.2-->
     <setting name="tasks" value="deploy" />
     <setting name="vmparams" value="-Xms512M -Xmx1024M -Xss1M -XX:+CMSClassUnloadingEnabled" />
     <setting name="workingDir" value="$PROJECT_DIR$" />
+
+    <!-- for IntelliJ >= 2019.2 -->
+    <option name="allowRunningInParallel" value="false" />
+    <option name="tasks" value="deploy" />
+    <option name="useSbtShell" value="false" />
+    <option name="vmparams" value="-Xms512M -Xmx1024M -Xss1M -XX:+CMSClassUnloadingEnabled" />
+    <option name="workingDir" value="$PROJECT_DIR$" />
+
+    <!-- used by all IntelliJ versions -->
     <envs />
     <method />
   </configuration>

--- a/.idea/runConfigurations/Fetch_plugins__sbt_fetch_.xml
+++ b/.idea/runConfigurations/Fetch_plugins__sbt_fetch_.xml
@@ -1,9 +1,19 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Fetch plugins (sbt fetch)" type="SbtRunConfiguration" factoryName="sbt Task">
+    <!-- for IntelliJ < 2019.2-->
     <setting name="tasks" value="fetch" />
     <setting name="vmparams" value="-Xms512M -Xmx1024M -Xss1M -XX:+CMSClassUnloadingEnabled" />
     <setting name="workingDir" value="$PROJECT_DIR$" />
     <setting name="useSbtShell" value="false" />
+
+    <!-- for IntelliJ >= 2019.2 -->
+    <option name="allowRunningInParallel" value="false" />
+    <option name="tasks" value="fetch" />
+    <option name="useSbtShell" value="false" />
+    <option name="vmparams" value="-Xms512M -Xmx1024M -Xss1M -XX:+CMSClassUnloadingEnabled" />
+    <option name="workingDir" value="$PROJECT_DIR$" />
+
+    <!-- used by all IntelliJ versions -->
     <method v="2" />
   </configuration>
 </component>

--- a/.idea/runConfigurations/List_plugin_versions__sbt_version_.xml
+++ b/.idea/runConfigurations/List_plugin_versions__sbt_version_.xml
@@ -1,8 +1,18 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="List plugin versions (sbt version)" type="SbtRunConfiguration" factoryName="sbt Task">
+    <!-- for IntelliJ < 2019.2-->
     <setting name="tasks" value="version" />
     <setting name="vmparams" value="-Xms512M -Xmx1024M -Xss1M -XX:+CMSClassUnloadingEnabled" />
     <setting name="workingDir" value="$PROJECT_DIR$" />
+
+    <!-- for IntelliJ >= 2019.2 -->
+    <option name="allowRunningInParallel" value="false" />
+    <option name="tasks" value="version" />
+    <option name="useSbtShell" value="false" />
+    <option name="vmparams" value="-Xms512M -Xmx1024M -Xss1M -XX:+CMSClassUnloadingEnabled" />
+    <option name="workingDir" value="$PROJECT_DIR$" />
+
+    <!-- used by all IntelliJ versions -->
     <envs />
     <method />
   </configuration>

--- a/.idea/runConfigurations/Package_and_copy_plugins__sbt_package_copy_.xml
+++ b/.idea/runConfigurations/Package_and_copy_plugins__sbt_package_copy_.xml
@@ -1,8 +1,18 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Package and copy plugins (sbt package copy)" type="SbtRunConfiguration" factoryName="sbt Task">
+    <!-- for IntelliJ < 2019.2-->
     <setting name="tasks" value="package copy" />
     <setting name="vmparams" value="-Xms512M -Xmx1024M -Xss1M -XX:+CMSClassUnloadingEnabled" />
     <setting name="workingDir" value="$PROJECT_DIR$" />
+
+    <!-- for IntelliJ >= 2019.2 -->
+    <option name="allowRunningInParallel" value="false" />
+    <option name="tasks" value="package copy" />
+    <option name="useSbtShell" value="false" />
+    <option name="vmparams" value="-Xms512M -Xmx1024M -Xss1M -XX:+CMSClassUnloadingEnabled" />
+    <option name="workingDir" value="$PROJECT_DIR$" />
+
+    <!-- used by all IntelliJ versions -->
     <envs />
     <method />
   </configuration>

--- a/.idea/runConfigurations/Reload__sbt_reload_.xml
+++ b/.idea/runConfigurations/Reload__sbt_reload_.xml
@@ -1,8 +1,18 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Reload (sbt reload)" type="SbtRunConfiguration" factoryName="sbt Task">
+    <!-- for IntelliJ < 2019.2-->
     <setting name="tasks" value="reload" />
     <setting name="vmparams" value="-Xms512M -Xmx1024M -Xss1M -XX:+CMSClassUnloadingEnabled" />
     <setting name="workingDir" value="$PROJECT_DIR$" />
+
+    <!-- for IntelliJ >= 2019.2 -->
+    <option name="allowRunningInParallel" value="false" />
+    <option name="tasks" value="reload" />
+    <option name="useSbtShell" value="false" />
+    <option name="vmparams" value="-Xms512M -Xmx1024M -Xss1M -XX:+CMSClassUnloadingEnabled" />
+    <option name="workingDir" value="$PROJECT_DIR$" />
+
+    <!-- used by all IntelliJ versions -->
     <envs />
     <method />
   </configuration>


### PR DESCRIPTION
The newly released IntelliJ 2019.2 has made changes to the run configurations affecting our sbt configs. The tag `setting` has been renamed to `option`. Opening the project with the new version fails and replaces all sbt configs with dummies that obviously don't work correctly.

This pr adds the required `option` tags while leaving `settings` tags alone. This enables support for the new version and backwards compatibility to the older versions (tested on 2019.2 and 2019.1.3).