### PR TITLE
Implement Coursier for plugin dependency resolution and fetching

### DIFF
--- a/bootstrap/build.sbt
+++ b/bootstrap/build.sbt
@@ -5,3 +5,5 @@ assemblyJarName in assembly := "ChatOverflow.jar"
 libraryDependencies += "org.scala-lang.modules" %% "scala-xml" % "1.1.1"
 libraryDependencies += "org.jline" % "jline-terminal-jansi" % "3.11.0" // used for terminal width
 fork := true
+
+packageBin / includePom := false

--- a/build.sbt
+++ b/build.sbt
@@ -135,6 +135,7 @@ Compile / packageBin := {
 }
 
 Compile / unmanagedJars := (crossTarget.value ** "chatoverflow-gui*.jar").classpath
+packageBin / includePom := false
 
 // ---------------------------------------------------------------------------------------------------------------------
 // UTIL

--- a/build.sbt
+++ b/build.sbt
@@ -89,6 +89,9 @@ libraryDependencies += "com.fazecast" % "jSerialComm" % "[2.0.0,3.0.0)"
 // Socket.io
 libraryDependencies += "io.socket" % "socket.io-client" % "1.0.0"
 
+// Coursier
+libraryDependencies += "io.get-coursier" %% "coursier" % "2.0.0-RC3-2"
+
 // ---------------------------------------------------------------------------------------------------------------------
 // PLUGIN FRAMEWORK DEFINITIONS
 // ---------------------------------------------------------------------------------------------------------------------

--- a/build/src/main/scala/org/codeoverflow/chatoverflow/build/PomInclusionPlugin.scala
+++ b/build/src/main/scala/org/codeoverflow/chatoverflow/build/PomInclusionPlugin.scala
@@ -1,0 +1,47 @@
+package org.codeoverflow.chatoverflow.build
+
+import sbt._
+import sbt.Keys._
+import sbt.plugins.JvmPlugin
+
+/**
+ * A sbt plugin to automatically include the dependencies of a sbt project in the jar as a pom file called "dependencies.pom".
+ */
+object PomInclusionPlugin extends AutoPlugin {
+
+  // Everything in autoImport will be visible to sbt project files
+  // They can set this value to false if they don't want to include their dependencies as a pom file
+  object autoImport {
+    val includePom = settingKey[Boolean]("Whether to include a pom file inside the jar with all dependencies.")
+  }
+  import autoImport._
+
+  // We require to have the Compile configuration and the packageBin task to override
+  override def requires = JvmPlugin
+  override def trigger = allRequirements
+
+  // Adds our custom task before the packageBin task
+  override val projectSettings: Seq[Def.Setting[_]] =
+    inConfig(Compile)(Seq(
+      Compile / packageBin := {
+        addPomToOutput.value
+        (Compile / packageBin).value
+      }
+    ))
+
+  // Sets default values
+  override def buildSettings: Seq[Def.Setting[_]] = inConfig(Compile)(
+    includePom in packageBin := true
+  )
+
+  // Just copies the pom resulted by makePom into the directory for compiled classes
+  // That way the file will be included in the jar
+  private lazy val addPomToOutput = Def.taskDyn {
+    if ((includePom in packageBin).value) Def.task {
+      val pomFile = (Compile / makePom).value
+
+      IO.copyFile(pomFile, new File((Compile / classDirectory).value, "dependencies.pom"))
+    } else
+      Def.task {} // if disabled, do nothing
+  }
+}

--- a/src/main/scala/org/codeoverflow/chatoverflow/framework/PluginFramework.scala
+++ b/src/main/scala/org/codeoverflow/chatoverflow/framework/PluginFramework.scala
@@ -103,7 +103,8 @@ class PluginFramework(pluginDirectoryPath: String) extends WithLogger {
         }
       }
 
-      futures.foreach(f => Await.ready(f, 10.seconds))
+      // If plugins aren't done within this timeout they can still fetch everything in the background, they just won't be included in this summary
+      futures.foreach(f => Await.ready(f, 5.seconds))
 
       logger info s"Loaded ${pluginTypes.length} plugin types in total: " +
         s"${pluginTypes.map(pt => s"${pt.getName} (${pt.getAuthor})").mkString(", ")}"

--- a/src/main/scala/org/codeoverflow/chatoverflow/framework/PluginType.scala
+++ b/src/main/scala/org/codeoverflow/chatoverflow/framework/PluginType.scala
@@ -1,25 +1,31 @@
 package org.codeoverflow.chatoverflow.framework
 
+import java.io.File
+
 import org.codeoverflow.chatoverflow.WithLogger
 import org.codeoverflow.chatoverflow.api.APIVersion
 import org.codeoverflow.chatoverflow.api.plugin.{Plugin, PluginManager}
 import org.codeoverflow.chatoverflow.framework.PluginCompatibilityState.PluginCompatibilityState
 
+import scala.concurrent.Future
+
 /**
-  * A plugin type is a container for all information about a plugin, everything in the 'plugin.xml' and the actual class.
-  * The plugins functionality and meta information can be accessed through this interface.
-  *
-  * @param name            the name of the plugin, used for identifying
-  * @param author          the author of the plugin, used for identifying
-  * @param version         the version of the plugin
-  * @param majorAPIVersion the major api version, with which the plugin was developed
-  * @param minorAPIVersion the minor api version, with which the plugin was developed
-  * @param pluginClass     the class of the plugin, used to create instances of this plugin.
-  *                        Needs to have a constructor with the signature of one PluginManager,
-  *                        otherwise instances can't be created from it.
-  */
+ * A plugin type is a container for all information about a plugin, everything in the 'plugin.xml' and the actual class.
+ * The plugins functionality and meta information can be accessed through this interface.
+ *
+ * @param name               the name of the plugin, used for identifying
+ * @param author             the author of the plugin, used for identifying
+ * @param version            the version of the plugin
+ * @param majorAPIVersion    the major api version, with which the plugin was developed
+ * @param minorAPIVersion    the minor api version, with which the plugin was developed
+ * @param pluginClass        the class of the plugin, used to create instances of this plugin.
+ *                           Needs to have a constructor with the signature of one PluginManager,
+ *                           otherwise instances can't be created from it.
+ * @param pluginDependencies A future that completes when all dependencies, that the plugin has, are available and
+ *                           that returns a seq of the required dependencies files in the local coursier cache.
+ */
 class PluginType(name: String, author: String, version: String, majorAPIVersion: Int, minorAPIVersion: Int,
-                 metadata: PluginMetadata, pluginClass: Class[_ <: Plugin]) extends WithLogger {
+                 metadata: PluginMetadata, pluginClass: Class[_ <: Plugin], pluginDependencies: Future[Seq[File]]) extends WithLogger {
 
   private var pluginVersionState = PluginCompatibilityState.Untested
 
@@ -126,4 +132,12 @@ class PluginType(name: String, author: String, version: String, majorAPIVersion:
     * @return the PluginMetadata instance of this plugin
     */
   def getMetadata: PluginMetadata = metadata
+
+  /**
+   * Returns the future that will result in a sequence of jar files that represents the dependencies
+   * of this plugin including all sub-dependencies.
+   *
+   * @return the dependency future
+   */
+  def getDependencyFuture: Future[Seq[File]] = pluginDependencies
 }

--- a/src/main/scala/org/codeoverflow/chatoverflow/framework/helper/CoursierUtils.scala
+++ b/src/main/scala/org/codeoverflow/chatoverflow/framework/helper/CoursierUtils.scala
@@ -1,0 +1,58 @@
+package org.codeoverflow.chatoverflow.framework.helper
+
+import java.io.{File, InputStream}
+
+import coursier.Fetch
+import coursier.cache.{CacheLogger, FileCache}
+import coursier.core.Dependency
+import coursier.maven.PomParser
+import org.codeoverflow.chatoverflow.WithLogger
+
+import scala.io.Source
+
+/**
+ * A utility object containing some common code for use with Coursier.
+ */
+object CoursierUtils extends WithLogger {
+
+  private object CoursierLogger extends CacheLogger {
+    override def downloadedArtifact(url: String, success: Boolean): Unit = {
+      logger debug (if (success)
+        s"Successfully downloaded $url"
+      else
+        s"Failed to download $url")
+    }
+  }
+
+  private val cache = FileCache().noCredentials.withLogger(CoursierLogger)
+
+  /**
+   * Extracts all dependencies out of the provided pom. Throws an exception if the pom is invalid.
+   *
+   * @param is the InputStream from which the pom is read
+   * @return a seq of all found dependencies
+   */
+  def parsePom(is: InputStream): Seq[Dependency] = {
+    val pomFile = Source.fromInputStream(is)
+    val parser = coursier.core.compatibility.xmlParseSax(pomFile.mkString, new PomParser)
+
+    parser.project match {
+      case Right(deps) => deps.dependencies.map(_._2)
+      case Left(errorMsg) => throw new IllegalArgumentException(s"Pom couldn't be parsed: $errorMsg")
+    }
+  }
+
+  /**
+   * Resolves and fetches all passed dependencies and gives back a seq of all local files of these dependencies.
+   *
+   * @param dependencies all dependencies that you want to be fetched
+   * @return all local files for the passed dependencies
+   */
+  def fetchDependencies(dependencies: Seq[Dependency]): Seq[File] = {
+    // IntelliJ may warn you that a implicit is missing. This is one of the many bugs in IntelliJ, the code compiles fine.
+    Fetch()
+      .withCache(cache)
+      .addDependencies(dependencies: _*)
+      .run()
+  }
+}

--- a/src/main/scala/org/codeoverflow/chatoverflow/framework/helper/PluginClassLoader.scala
+++ b/src/main/scala/org/codeoverflow/chatoverflow/framework/helper/PluginClassLoader.scala
@@ -2,12 +2,52 @@ package org.codeoverflow.chatoverflow.framework.helper
 
 import java.net.{URL, URLClassLoader}
 
+import org.codeoverflow.chatoverflow.WithLogger
+
 /**
- * This plugin class loader does only exist for plugin security policy checks and
- * to expose the addURL method to the package inorder to add all required dependencies after dependency resolution.
+ * This plugin class loader is used for plugin security policy checks,
+ * to expose the addURL method to the package inorder to add all required dependencies after dependency resolution
+ * and most importantly to isolate the plugin from the normal classpath and only access the classpath if it needs to load the ChatOverflow api.
+ * Also if this PluginClassLoader had access to the classpath the same classes of the classpath would have
+ * higher priority over the classes in this classloader which could be a problem  if a plugin uses a newer version
+ * of a dependency that the framework.
  *
  * @param urls Takes an array of urls an creates a simple URLClassLoader with it
  */
-class PluginClassLoader(urls: Array[URL]) extends URLClassLoader(urls) {
+class PluginClassLoader(urls: Array[URL]) extends URLClassLoader(urls, PluginClassLoader.platformClassloader) {
+  // Note the platform classloader in the constructor of the URLClassLoader as the parent.
+  // That way the classloader skips the app classloader with the classpath when it is asks it's parents for classes.
+
   protected[helper] override def addURL(url: URL): Unit = super.addURL(url) // just exposes this method to be package-private instead of class internal protected
+
+  override def loadClass(name: String, resolve: Boolean): Class[_] = {
+    if (name.startsWith("org.codeoverflow.chatoverflow.api")) {
+      PluginClassLoader.appClassloader.loadClass(name) // Api needs to be loaded from the classpath
+    } else {
+      super.loadClass(name, resolve) // non api class. load it as normal
+    }
+  }
+}
+
+/**
+ * This companion object holds references to the app classloader (normal classloader, includes java and classpath)
+ * and to the extension/platform classloader depending on the java version that excludes the classpath,
+ * but still includes everything from java.
+ */
+private object PluginClassLoader extends WithLogger {
+  val appClassloader: ClassLoader = this.getClass.getClassLoader
+  val platformClassloader: ClassLoader = {
+    var current = appClassloader
+    while (current != null && !current.getClass.getName.contains("ExtClassLoader") && // ExtClassLoader is java < 9
+      !current.getClass.getName.contains("PlatformClassLoader")) { // PlatformClassLoader is java >= 9
+      current = current.getParent
+    }
+
+    if (current != null) {
+      current
+    } else {
+      logger error "Platform classloader couldn't be found. Falling back to normal app classloader."
+      appClassloader
+    }
+  }
 }

--- a/src/main/scala/org/codeoverflow/chatoverflow/framework/helper/PluginClassLoader.scala
+++ b/src/main/scala/org/codeoverflow/chatoverflow/framework/helper/PluginClassLoader.scala
@@ -3,8 +3,11 @@ package org.codeoverflow.chatoverflow.framework.helper
 import java.net.{URL, URLClassLoader}
 
 /**
-  * This plugin class loader does only exist for plugin security policy checks.
-  *
-  * @param urls Takes an array of urls an creates a simple URLClassLoader with it
-  */
-class PluginClassLoader(urls: Array[URL]) extends URLClassLoader(urls)
+ * This plugin class loader does only exist for plugin security policy checks and
+ * to expose the addURL method to the package inorder to add all required dependencies after dependency resolution.
+ *
+ * @param urls Takes an array of urls an creates a simple URLClassLoader with it
+ */
+class PluginClassLoader(urls: Array[URL]) extends URLClassLoader(urls) {
+  private[helper] override def addURL(url: URL): Unit = super.addURL(url) // just exposes this method to be package-private instead of protected
+}

--- a/src/main/scala/org/codeoverflow/chatoverflow/framework/helper/PluginClassLoader.scala
+++ b/src/main/scala/org/codeoverflow/chatoverflow/framework/helper/PluginClassLoader.scala
@@ -9,5 +9,5 @@ import java.net.{URL, URLClassLoader}
  * @param urls Takes an array of urls an creates a simple URLClassLoader with it
  */
 class PluginClassLoader(urls: Array[URL]) extends URLClassLoader(urls) {
-  private[helper] override def addURL(url: URL): Unit = super.addURL(url) // just exposes this method to be package-private instead of protected
+  protected[helper] override def addURL(url: URL): Unit = super.addURL(url) // just exposes this method to be package-private instead of class internal protected
 }

--- a/src/main/scala/org/codeoverflow/chatoverflow/instance/PluginInstance.scala
+++ b/src/main/scala/org/codeoverflow/chatoverflow/instance/PluginInstance.scala
@@ -100,7 +100,7 @@ class PluginInstance(val instanceName: String, pluginType: PluginType) extends W
         } else {
 
           if (!areDependenciesAvailable) {
-            logger error "Dependencies have failed to resolve and fetch."
+            logger error "Dependencies have either failed to resolve and fetch or aren't done yet."
             return false
           }
 
@@ -232,7 +232,7 @@ class PluginInstance(val instanceName: String, pluginType: PluginType) extends W
   /**
    * Returns whether all dependencies are resolved and fetched which is required for the plugin to start.
    *
-   * @return true if all dependencies are available, true if it has failed.
+   * @return true if all dependencies are available, false if it has failed or aren't downloaded yet.
    */
   def areDependenciesAvailable: Boolean = {
     val opt = pluginType.getDependencyFuture.value

--- a/src/main/scala/org/codeoverflow/chatoverflow/instance/PluginInstance.scala
+++ b/src/main/scala/org/codeoverflow/chatoverflow/instance/PluginInstance.scala
@@ -99,6 +99,11 @@ class PluginInstance(val instanceName: String, pluginType: PluginType) extends W
 
         } else {
 
+          if (!areDependenciesAvailable) {
+            logger error "Dependencies have either failed to resolve and fetch or aren't done yet."
+            return false
+          }
+
           // This is set to false if any connector (aka input/output) is not ready.
           var allConnectorsReady = true
 
@@ -222,6 +227,16 @@ class PluginInstance(val instanceName: String, pluginType: PluginType) extends W
       logger error s"Plugin instance '$instanceName' does not exist."
       new Requirements()
     }
+  }
+
+  /**
+   * Returns whether all dependencies are resolved and fetch which is required for the plugin to start.
+   *
+   * @return true if all dependencies are available, true if not done of failed.
+   */
+  def areDependenciesAvailable: Boolean = {
+    val opt = pluginType.getDependencyFuture.value
+    opt.isDefined && opt.get.isSuccess
   }
 
   /**

--- a/src/main/scala/org/codeoverflow/chatoverflow/instance/PluginInstance.scala
+++ b/src/main/scala/org/codeoverflow/chatoverflow/instance/PluginInstance.scala
@@ -100,7 +100,7 @@ class PluginInstance(val instanceName: String, pluginType: PluginType) extends W
         } else {
 
           if (!areDependenciesAvailable) {
-            logger error "Dependencies have either failed to resolve and fetch or aren't done yet."
+            logger error "Dependencies have failed to resolve and fetch."
             return false
           }
 
@@ -230,9 +230,9 @@ class PluginInstance(val instanceName: String, pluginType: PluginType) extends W
   }
 
   /**
-   * Returns whether all dependencies are resolved and fetch which is required for the plugin to start.
+   * Returns whether all dependencies are resolved and fetched which is required for the plugin to start.
    *
-   * @return true if all dependencies are available, true if not done of failed.
+   * @return true if all dependencies are available, true if it has failed.
    */
   def areDependenciesAvailable: Boolean = {
     val opt = pluginType.getDependencyFuture.value

--- a/src/main/scala/org/codeoverflow/chatoverflow/ui/web/rest/plugin/PluginInstanceController.scala
+++ b/src/main/scala/org/codeoverflow/chatoverflow/ui/web/rest/plugin/PluginInstanceController.scala
@@ -47,7 +47,7 @@ class PluginInstanceController(implicit val swagger: Swagger) extends JsonServle
               ResultMessage(success = false, "Not all required requirements have been set.")
 
             } else if (!pluginInstance.get.areDependenciesAvailable) {
-              ResultMessage(success = false, "Dependencies have either failed to resolve and fetch or aren't done yet. Check logs for further information.")
+              ResultMessage(success = false, "Dependencies have failed to resolve and fetch. Check logs for further information.")
 
             } else if (!pluginInstance.get.start()) {
               ResultMessage(success = false, "Unable to start plugin.")

--- a/src/main/scala/org/codeoverflow/chatoverflow/ui/web/rest/plugin/PluginInstanceController.scala
+++ b/src/main/scala/org/codeoverflow/chatoverflow/ui/web/rest/plugin/PluginInstanceController.scala
@@ -46,6 +46,9 @@ class PluginInstanceController(implicit val swagger: Swagger) extends JsonServle
             } else if (!pluginInstance.get.getRequirements.getAccess.isComplete) {
               ResultMessage(success = false, "Not all required requirements have been set.")
 
+            } else if (!pluginInstance.get.areDependenciesAvailable) {
+              ResultMessage(success = false, "Dependencies have either failed to resolve and fetch or aren't done yet. Check logs for further information.")
+
             } else if (!pluginInstance.get.start()) {
               ResultMessage(success = false, "Unable to start plugin.")
 

--- a/src/main/scala/org/codeoverflow/chatoverflow/ui/web/rest/plugin/PluginInstanceController.scala
+++ b/src/main/scala/org/codeoverflow/chatoverflow/ui/web/rest/plugin/PluginInstanceController.scala
@@ -47,7 +47,7 @@ class PluginInstanceController(implicit val swagger: Swagger) extends JsonServle
               ResultMessage(success = false, "Not all required requirements have been set.")
 
             } else if (!pluginInstance.get.areDependenciesAvailable) {
-              ResultMessage(success = false, "Dependencies have failed to resolve and fetch. Check logs for further information.")
+              ResultMessage(success = false, "Dependencies have either failed to resolve and fetch or aren't done yet. Check logs for further information.")
 
             } else if (!pluginInstance.get.start()) {
               ResultMessage(success = false, "Unable to start plugin.")


### PR DESCRIPTION
Implements Coursier to download dependencies that are required by plugins and the sbt auto-plugin to include the pom files of plugins inside the jar like discussed in #105.
The sbt plugin is automatically in all projects active unless deactivated like this PR does for the framework.

This PR also updates the `PluginClassLoader` to always have the platform/extension class loader as it's parent. This ensures that plugins get the dependencies of their pom file. If the same class of a dependency also exists in the classloader of the framework the class of the framework would have higher priority than the one in the plugin class loader. By having the platform/extension class loader as a parent the class can only come from java or the plugin class loader with the wanted version of the dependencies added.

A caching class loader isn't in this PR tough. I don't have enough time for that before my vacation. 

API PR: https://github.com/codeoverflow-org/chatoverflow-api/pull/15
Plugins-public PR: https://github.com/codeoverflow-org/chatoverflow-plugins/pull/2