### PR TITLE
Add a EventConnector and a general trait for handling events called EventManager

### DIFF
--- a/src/main/scala/org/codeoverflow/chatoverflow/connector/Connector.scala
+++ b/src/main/scala/org/codeoverflow/chatoverflow/connector/Connector.scala
@@ -24,6 +24,7 @@ abstract class Connector(val sourceIdentifier: String) extends WithLogger {
   protected var requiredCredentialKeys: List[String]
   protected var optionalCredentialKeys: List[String]
   protected var running = false
+  protected implicit val identifier: String = hashCode().toString
 
   private var instanceCount = 0
 

--- a/src/main/scala/org/codeoverflow/chatoverflow/connector/EventConnector.scala
+++ b/src/main/scala/org/codeoverflow/chatoverflow/connector/EventConnector.scala
@@ -1,0 +1,11 @@
+package org.codeoverflow.chatoverflow.connector
+
+import org.codeoverflow.chatoverflow.requirement.impl.EventManager
+
+/**
+ * A connector is used to connect a input / output service to its dedicated platform.
+ * Also has methods to register and fire events.
+ *
+ * @param sourceIdentifier the unique source identifier (e.g. a login name), the connector should work with
+ */
+abstract class EventConnector(sourceIdentifier: String) extends Connector(sourceIdentifier) with EventManager

--- a/src/main/scala/org/codeoverflow/chatoverflow/requirement/impl/EventHandler.scala
+++ b/src/main/scala/org/codeoverflow/chatoverflow/requirement/impl/EventHandler.scala
@@ -1,7 +1,0 @@
-package org.codeoverflow.chatoverflow.requirement.impl
-
-import java.util.function.Consumer
-
-import org.codeoverflow.chatoverflow.api.io.event.Event
-
-private[impl] case class EventHandler[T <: Event](consumer: Consumer[T], clazz: Class[T])

--- a/src/main/scala/org/codeoverflow/chatoverflow/requirement/impl/EventManager.scala
+++ b/src/main/scala/org/codeoverflow/chatoverflow/requirement/impl/EventManager.scala
@@ -1,0 +1,99 @@
+package org.codeoverflow.chatoverflow.requirement.impl
+
+import scala.collection.mutable.ListBuffer
+import scala.reflect.ClassTag
+
+/**
+ * A class with common methods for event managing like register methods and a protected method to fire events.
+ */
+trait EventManager {
+  private val eventHandlers = ListBuffer[EventHandler[_]]()
+
+  /**
+   * Fires a event and calls all registered handlers.
+   *
+   * @param eventValue the actual value of the event.
+   * @param classTag   a class tag to be able to have access to the class of the event after type erasure.
+   * @tparam T the type/class of the event
+   */
+  protected def call[T: ClassTag](eventValue: T)(implicit classTag: ClassTag[T]): Unit = {
+    eventHandlers.foreach(_.handle(eventValue))
+  }
+
+  /**
+   * Registers a event handler for the given type and sub-types.
+   *
+   * @param handler    the handler that will be called if this type of event gets fired
+   * @param identifier a identifier of the registerer, used by the unregister method to identify who registered what.
+   * @tparam T the type for which you want to
+   */
+  def registerEventHandler[T: ClassTag](handler: T => Unit)(implicit identifier: String): Unit = {
+    eventHandlers += SingleEventHandler(identifier, handler)
+  }
+
+  /**
+   * Registers a event handler that will receive all events.
+   *
+   * @param handler    the handler that will be called if a event gets fired, includes a class tag to be able
+   *                   to get the class of the event.
+   * @param identifier a identifier of the registerer, used by the unregister method to identify who registered what.
+   */
+  def registerEventHandler(handler: (Any, ClassTag[Any]) => Unit)(implicit identifier: String): Unit = {
+    eventHandlers += AllEventHandler(identifier, handler)
+  }
+
+  /**
+   * Unregisters all handlers that were registered by the passed identifier.
+   *
+   * @param identifier a identifier of the registerer, anything registered with this identifier will be unregistered.
+   */
+  def unregisterAllEventListeners(implicit identifier: String): Unit = {
+    eventHandlers --= eventHandlers.filter(_.identifier == identifier)
+  }
+
+  /**
+   * A instance containg all required information about a event handler with a method to actually handle events.
+   *
+   * @param identifier the identifier used by the unregister method
+   * @param ct         the class tag to get a instance of the class of type T at runtime
+   * @tparam T the type of the event that this handler wants to handle
+   */
+  private abstract class EventHandler[T: ClassTag](val identifier: String)(implicit val ct: ClassTag[T]) {
+    /**
+     * Handles the passed event value. Also has to determine if the handler actually wants to handle this event
+     *
+     * @param eventValue    the value of the event
+     * @param eventClassTag the class tag to get the class of the event
+     */
+    def handle(eventValue: Any)(implicit eventClassTag: ClassTag[T]): Unit
+  }
+
+  /**
+   * A event handler that only wants to handle a single specific type of events.
+   *
+   * @param identifier the identifier used by the unregister method
+   * @param handler    a simple anonymous function to handle the event
+   * @param ct         the class tag to get a instance of the class of type T at runtime
+   * @tparam T the type of the event that this handler wants to handle
+   */
+  private case class SingleEventHandler[T: ClassTag](override val identifier: String, handler: T => Unit)(implicit ct: ClassTag[T]) extends EventHandler[T](identifier)(ct, ct) {
+    override def handle(eventValue: Any)(implicit eventClassTag: ClassTag[T]): Unit = {
+      if (ct.runtimeClass.isAssignableFrom(eventClassTag.runtimeClass))
+        handler.asInstanceOf[T => Unit].apply(eventValue.asInstanceOf[T])
+    }
+  }
+
+  /**
+   * A event handler that handles all types of events.
+   *
+   * @param identifier the identifier used by the unregister method
+   * @param handler    a simple anonymous function to handle the event, also gets a class tag passed to identify the class at runtime.
+   * @tparam T the type of the event that this handler wants to handle
+   */
+  private case class AllEventHandler[T: ClassTag](override val identifier: String, handler: (Any, ClassTag[Any]) => Unit) extends EventHandler[T](identifier) {
+    override def handle(eventValue: Any)(implicit eventClassTag: ClassTag[T]): Unit = {
+      handler(eventValue, eventClassTag.asInstanceOf[ClassTag[Any]])
+    }
+  }
+
+}

--- a/src/main/scala/org/codeoverflow/chatoverflow/requirement/impl/InputImpl.scala
+++ b/src/main/scala/org/codeoverflow/chatoverflow/requirement/impl/InputImpl.scala
@@ -9,6 +9,8 @@ import scala.reflect.ClassTag
 
 abstract class InputImpl[C <: Connector](implicit ct: ClassTag[C]) extends Connection[C] with Input with WithLogger {
 
+  protected implicit val identifier: String = hashCode().toString
+
   /**
     * Init this connection, checks if the source connector is defined, and can be inited, then calls start
     *

--- a/src/main/scala/org/codeoverflow/chatoverflow/requirement/impl/OutputImpl.scala
+++ b/src/main/scala/org/codeoverflow/chatoverflow/requirement/impl/OutputImpl.scala
@@ -9,6 +9,8 @@ import scala.reflect.ClassTag
 
 abstract class OutputImpl[C <: Connector](implicit ct: ClassTag[C]) extends Connection[C] with Output with WithLogger {
 
+  protected implicit val identifier: String = hashCode().toString
+
   /**
     * Init this connection, checks if teh source connector is defined, and can be inited, then calls start
     *

--- a/src/main/scala/org/codeoverflow/chatoverflow/requirement/service/discord/DiscordChatConnector.scala
+++ b/src/main/scala/org/codeoverflow/chatoverflow/requirement/service/discord/DiscordChatConnector.scala
@@ -5,12 +5,10 @@ import java.util.function.Consumer
 
 import javax.security.auth.login.LoginException
 import net.dv8tion.jda.core.entities.{Message, MessageEmbed, TextChannel}
-import net.dv8tion.jda.core.events.message.react.{MessageReactionAddEvent, MessageReactionRemoveEvent}
-import net.dv8tion.jda.core.events.message.{MessageDeleteEvent, MessageReceivedEvent, MessageUpdateEvent}
 import net.dv8tion.jda.core.requests.RestAction
 import net.dv8tion.jda.core.{JDA, JDABuilder, MessageBuilder}
 import org.codeoverflow.chatoverflow.WithLogger
-import org.codeoverflow.chatoverflow.connector.Connector
+import org.codeoverflow.chatoverflow.connector.EventConnector
 import org.codeoverflow.chatoverflow.connector.actor.FileSystemActor
 import org.codeoverflow.chatoverflow.connector.actor.FileSystemActor.LoadBinaryFile
 
@@ -19,7 +17,7 @@ import org.codeoverflow.chatoverflow.connector.actor.FileSystemActor.LoadBinaryF
   *
   * @param sourceIdentifier the unique source identifier (in this implementation only for identifying)
   */
-class DiscordChatConnector(override val sourceIdentifier: String) extends Connector(sourceIdentifier) with WithLogger {
+class DiscordChatConnector(override val sourceIdentifier: String) extends EventConnector(sourceIdentifier) with WithLogger {
   private val discordChatListener = new DiscordChatListener
 
   private var jda: Option[JDA] = None
@@ -32,35 +30,7 @@ class DiscordChatConnector(override val sourceIdentifier: String) extends Connec
   private val defaultFailureHandler: Consumer[_ >: Throwable] =
     throwable => logger warn s"Rest action for connector $sourceIdentifier failed: ${throwable.getMessage}"
 
-  def addMessageReceivedListener(listener: MessageReceivedEvent => Unit): Unit =
-    discordChatListener.addMessageReceivedListener(listener)
-
-  def addMessageUpdateListener(listener: MessageUpdateEvent => Unit): Unit =
-    discordChatListener.addMessageUpdateEventListener(listener)
-
-  def addMessageDeleteListener(listener: MessageDeleteEvent => Unit): Unit =
-    discordChatListener.addMessageDeleteEventListener(listener)
-
-  def addReactionAddEventListener(listener: MessageReactionAddEvent => Unit): Unit =
-    discordChatListener.addReactionAddEventListener(listener)
-
-  def addReactionDelEventListener(listener: MessageReactionRemoveEvent => Unit): Unit =
-    discordChatListener.addReactionDelEventListener(listener)
-
-  def removeMessageReceivedListener(listener: MessageReceivedEvent => Unit): Unit =
-    discordChatListener.removeMessageReceivedListener(listener)
-
-  def removeMessageUpdateListener(listener: MessageUpdateEvent => Unit): Unit =
-    discordChatListener.removeMessageUpdateEventListener(listener)
-
-  def removeMessageDeleteListener(listener: MessageDeleteEvent => Unit): Unit =
-    discordChatListener.removeMessageDeleteEventListener(listener)
-
-  def removeReactionAddEventListener(listener: MessageReactionAddEvent => Unit): Unit =
-    discordChatListener.removeReactionAddEventListener(listener)
-
-  def removeReactionDelEventListener(listener: MessageReactionRemoveEvent => Unit): Unit =
-    discordChatListener.removeReactionDelEventListener(listener)
+  discordChatListener.registerEventHandler((event, ct) => call(event)(ct, ct))
 
   /**
     * Connects to discord

--- a/src/main/scala/org/codeoverflow/chatoverflow/requirement/service/discord/DiscordChatListener.scala
+++ b/src/main/scala/org/codeoverflow/chatoverflow/requirement/service/discord/DiscordChatListener.scala
@@ -4,52 +4,20 @@ import net.dv8tion.jda.core.events.Event
 import net.dv8tion.jda.core.events.message.react.{MessageReactionAddEvent, MessageReactionRemoveEvent}
 import net.dv8tion.jda.core.events.message.{MessageDeleteEvent, MessageReceivedEvent, MessageUpdateEvent}
 import net.dv8tion.jda.core.hooks.EventListener
-
-import scala.collection.mutable.ListBuffer
+import org.codeoverflow.chatoverflow.requirement.impl.EventManager
 
 /**
   * The discord chat listener class holds the handler to react to creation, edits and removal of messages using the rest api
   */
-class DiscordChatListener extends EventListener {
-
-  private val messageEventListener = ListBuffer[MessageReceivedEvent => Unit]()
-
-  private val messageUpdateEventListener = ListBuffer[MessageUpdateEvent => Unit]()
-
-  private val messageDeleteEventListener = ListBuffer[MessageDeleteEvent => Unit]()
-
-  private val reactionAddEventListener = ListBuffer[MessageReactionAddEvent => Unit]()
-
-  private val reactionDelEventListener = ListBuffer[MessageReactionRemoveEvent => Unit]()
-
-  def addMessageReceivedListener(listener: MessageReceivedEvent => Unit): Unit = messageEventListener += listener
-
-  def addMessageUpdateEventListener(listener: MessageUpdateEvent => Unit): Unit = messageUpdateEventListener += listener
-
-  def addMessageDeleteEventListener(listener: MessageDeleteEvent => Unit): Unit = messageDeleteEventListener += listener
-
-  def addReactionAddEventListener(listener: MessageReactionAddEvent => Unit): Unit = reactionAddEventListener += listener
-
-  def addReactionDelEventListener(listener: MessageReactionRemoveEvent => Unit): Unit = reactionDelEventListener += listener
-
-  def removeMessageReceivedListener(listener: MessageReceivedEvent => Unit): Unit = messageEventListener -= listener
-
-  def removeMessageUpdateEventListener(listener: MessageUpdateEvent => Unit): Unit = messageUpdateEventListener -= listener
-
-  def removeMessageDeleteEventListener(listener: MessageDeleteEvent => Unit): Unit = messageDeleteEventListener -= listener
-
-  def removeReactionAddEventListener(listener: MessageReactionAddEvent => Unit): Unit = reactionAddEventListener -= listener
-
-  def removeReactionDelEventListener(listener: MessageReactionRemoveEvent => Unit): Unit = reactionDelEventListener -= listener
+class DiscordChatListener extends EventListener with EventManager {
 
   override def onEvent(event: Event): Unit = {
-    event match {
-      case receivedEvent: MessageReceivedEvent => messageEventListener.foreach(listener => listener(receivedEvent))
-      case updateEvent: MessageUpdateEvent => messageUpdateEventListener.foreach(listener => listener(updateEvent))
-      case deleteEvent: MessageDeleteEvent => messageDeleteEventListener.foreach(listener => listener(deleteEvent))
-      case reactionAddEvent: MessageReactionAddEvent => reactionAddEventListener.foreach(listener => listener(reactionAddEvent))
-      case reactionDelEvent: MessageReactionRemoveEvent => reactionDelEventListener.foreach(listener => listener(reactionDelEvent))
-      case _ => //Any other event, do nothing
+    val listeningClasses = List(classOf[MessageReceivedEvent], classOf[MessageUpdateEvent], classOf[MessageDeleteEvent],
+      classOf[MessageReactionAddEvent], classOf[MessageReactionRemoveEvent])
+
+    // Only broadcast event if we are listening for it (above list)
+    if (listeningClasses.contains(event.getClass)) {
+      call(event)
     }
   }
 }

--- a/src/main/scala/org/codeoverflow/chatoverflow/requirement/service/discord/impl/DiscordChatInputImpl.scala
+++ b/src/main/scala/org/codeoverflow/chatoverflow/requirement/service/discord/impl/DiscordChatInputImpl.scala
@@ -34,18 +34,12 @@ class DiscordChatInputImpl extends EventInputImpl[DiscordEvent, DiscordChatConne
   private val privateMessages = ListBuffer[DiscordChatMessage]()
   private var channelId: Option[String] = None
 
-  private val onMessageFn = onMessage _
-  private val onMessageUpdateFn = onMessageUpdate _
-  private val onMessageDeleteFn = onMessageDelete _
-  private val onReactionAddedFn = onReactionAdded _
-  private val onReactionRemovedFn = onReactionRemoved _
-
   override def start(): Boolean = {
-    sourceConnector.get.addMessageReceivedListener(onMessageFn)
-    sourceConnector.get.addMessageUpdateListener(onMessageUpdateFn)
-    sourceConnector.get.addMessageDeleteListener(onMessageDeleteFn)
-    sourceConnector.get.addReactionAddEventListener(onReactionAddedFn)
-    sourceConnector.get.addReactionDelEventListener(onReactionRemovedFn)
+    sourceConnector.get.registerEventHandler(onMessage _)
+    sourceConnector.get.registerEventHandler(onMessageUpdate _)
+    sourceConnector.get.registerEventHandler(onMessageDelete _)
+    sourceConnector.get.registerEventHandler(onReactionAdded _)
+    sourceConnector.get.registerEventHandler(onReactionRemoved _)
     true
   }
 
@@ -88,11 +82,7 @@ class DiscordChatInputImpl extends EventInputImpl[DiscordEvent, DiscordChatConne
     * @return true if stopping was successful
     */
   override def stop(): Boolean = {
-    sourceConnector.get.removeMessageReceivedListener(onMessageFn)
-    sourceConnector.get.removeMessageUpdateListener(onMessageUpdateFn)
-    sourceConnector.get.removeMessageDeleteListener(onMessageDeleteFn)
-    sourceConnector.get.removeReactionAddEventListener(onReactionAddedFn)
-    sourceConnector.get.removeReactionDelEventListener(onReactionRemovedFn)
+    sourceConnector.get.unregisterAllEventListeners
     true
   }
 

--- a/src/main/scala/org/codeoverflow/chatoverflow/requirement/service/mockup/MockUpChatConnector.scala
+++ b/src/main/scala/org/codeoverflow/chatoverflow/requirement/service/mockup/MockUpChatConnector.scala
@@ -5,29 +5,21 @@ import java.time.temporal.ChronoUnit
 
 import org.codeoverflow.chatoverflow.WithLogger
 import org.codeoverflow.chatoverflow.api.io.dto.chat.{ChatEmoticon, ChatMessage, ChatMessageAuthor, TextChannel}
-import org.codeoverflow.chatoverflow.connector.Connector
+import org.codeoverflow.chatoverflow.connector.EventConnector
 
 import scala.collection.mutable.ListBuffer
 import scala.io.Source
 
 @Deprecated
-class MockUpChatConnector(sourceIdentifier: String) extends Connector(sourceIdentifier) with WithLogger {
+class MockUpChatConnector(sourceIdentifier: String) extends EventConnector(sourceIdentifier) with WithLogger {
 
   private val mockUpFolder = "src/main/resources/mockup"
   private val defaultDelay = 100
 
   private val parser = new ChatMessageParser()
-  private val messageListener = ListBuffer[ChatMessage[ChatMessageAuthor, TextChannel, ChatEmoticon] => Unit]()
   private var messages: List[ChatMessage[ChatMessageAuthor, TextChannel, ChatEmoticon]] = _
   private var elements: List[MockupElement] = _
   private var time: OffsetDateTime = OffsetDateTime.now
-
-  def addMessageEventListener(listener: ChatMessage[ChatMessageAuthor, TextChannel, ChatEmoticon] => Unit): Unit = {
-    messageListener += listener
-  }
-
-  def addPrivateMessageEventListener(listener: ChatMessage[ChatMessageAuthor, TextChannel, ChatEmoticon] => Unit): Unit = {
-  }
 
   def simulateChat(): Unit = {
     val step = 100
@@ -36,7 +28,7 @@ class MockUpChatConnector(sourceIdentifier: String) extends Connector(sourceIden
 
       val lastMessages = messages.filter(msg => msg.getTime.isAfter(currentTime.plus(step, ChronoUnit.MILLIS)) && !msg.getTime.isAfter(currentTime))
 
-      lastMessages.foreach(msg => messageListener.foreach(listener => listener(msg)))
+      lastMessages.foreach(msg => call(msg))
 
       Thread.sleep(step)
     }

--- a/src/main/scala/org/codeoverflow/chatoverflow/requirement/service/mockup/impl/MockUpChatInputImpl.scala
+++ b/src/main/scala/org/codeoverflow/chatoverflow/requirement/service/mockup/impl/MockUpChatInputImpl.scala
@@ -2,6 +2,7 @@ package org.codeoverflow.chatoverflow.requirement.service.mockup.impl
 
 import java.time.OffsetDateTime
 import java.time.temporal.ChronoUnit
+import java.util
 
 import org.codeoverflow.chatoverflow.WithLogger
 import org.codeoverflow.chatoverflow.api.io.dto.chat.{ChatEmoticon, ChatMessage, ChatMessageAuthor, TextChannel}
@@ -19,7 +20,6 @@ import scala.collection.mutable.ListBuffer
 class MockUpChatInputImpl extends EventInputImpl[MockupEvent, MockUpChatConnector] with MockUpChatInput with WithLogger {
 
   private val messages: ListBuffer[ChatMessage[ChatMessageAuthor, TextChannel, ChatEmoticon]] = ListBuffer[ChatMessage[ChatMessageAuthor, TextChannel, ChatEmoticon]]()
-  private val privateMessages: ListBuffer[ChatMessage[ChatMessageAuthor, TextChannel, ChatEmoticon]] = ListBuffer[ChatMessage[ChatMessageAuthor, TextChannel, ChatEmoticon]]()
 
   override def getLastMessages(lastMilliseconds: Long): java.util.List[ChatMessage[ChatMessageAuthor, TextChannel, ChatEmoticon]] = {
     val currentTime = OffsetDateTime.now
@@ -29,9 +29,7 @@ class MockUpChatInputImpl extends EventInputImpl[MockupEvent, MockUpChatConnecto
 
 
   override def getLastPrivateMessages(lastMilliseconds: Long): java.util.List[ChatMessage[ChatMessageAuthor, TextChannel, ChatEmoticon]] = {
-    val currentTime = OffsetDateTime.now
-
-    privateMessages.filter(_.getTime.isAfter(currentTime.minus(lastMilliseconds, ChronoUnit.MILLIS))).toList.asJava
+    new util.ArrayList() // Not yet implemented
   }
 
   override def serialize(): String = getSourceIdentifier
@@ -43,7 +41,10 @@ class MockUpChatInputImpl extends EventInputImpl[MockupEvent, MockUpChatConnecto
     *
     * @return true if starting the input was successful, false if some problems occurred
     */
-  override def start(): Boolean = true
+  override def start(): Boolean = {
+    sourceConnector.get.registerEventHandler[ChatMessage[ChatMessageAuthor, TextChannel, ChatEmoticon]](onMessage)
+    true
+  }
 
   /**
     * Stops the input, called before source connector will shutdown

--- a/src/main/scala/org/codeoverflow/chatoverflow/requirement/service/tipeeestream/impl/TipeeestreamEventInputImpl.scala
+++ b/src/main/scala/org/codeoverflow/chatoverflow/requirement/service/tipeeestream/impl/TipeeestreamEventInputImpl.scala
@@ -7,12 +7,13 @@ import java.util.Currency
 import org.codeoverflow.chatoverflow.WithLogger
 import org.codeoverflow.chatoverflow.api.io.dto.User
 import org.codeoverflow.chatoverflow.api.io.dto.stat.stream.tipeeestream.{TipeeestreamDonation, TipeeestreamFollow, TipeeestreamProvider, TipeeestreamSubscription}
-import org.codeoverflow.chatoverflow.api.io.event.stream.tipeeestream.{TipeeestreamFollowEvent, TipeeestreamDonationEvent, TipeeestreamEvent, TipeeestreamSubscriptionEvent}
+import org.codeoverflow.chatoverflow.api.io.event.stream.tipeeestream.{TipeeestreamDonationEvent, TipeeestreamEvent, TipeeestreamFollowEvent, TipeeestreamSubscriptionEvent}
 import org.codeoverflow.chatoverflow.api.io.input.event.TipeeestreamEventInput
 import org.codeoverflow.chatoverflow.registry.Impl
 import org.codeoverflow.chatoverflow.requirement.impl.EventInputImpl
 import org.codeoverflow.chatoverflow.requirement.service.tipeeestream.TipeeestreamConnector
-import org.json.{JSONException, JSONObject}
+import org.codeoverflow.chatoverflow.requirement.service.tipeeestream.TipeeestreamConnector._
+import org.json.JSONException
 
 @Impl(impl = classOf[TipeeestreamEventInput], connector = classOf[TipeeestreamConnector])
 class TipeeestreamEventInputImpl extends EventInputImpl[TipeeestreamEvent, TipeeestreamConnector] with TipeeestreamEventInput with WithLogger {
@@ -26,8 +27,9 @@ class TipeeestreamEventInputImpl extends EventInputImpl[TipeeestreamEvent, Tipee
     true
   }
 
-  private def onDonation(event: JSONObject): Unit = {
+  private def onDonation(eventJson: DonationEventJSON): Unit = {
     try {
+      val event = eventJson.json
       val parameter = event.getJSONObject("parameters")
       val user = new User(parameter.getString("username"))
       val message = parameter.getString("formattedMessage")
@@ -46,8 +48,9 @@ class TipeeestreamEventInputImpl extends EventInputImpl[TipeeestreamEvent, Tipee
     }
   }
 
-  private def onSubscription(event: JSONObject): Unit = {
+  private def onSubscription(eventJson: SubscriptionEventJSON): Unit = {
     try {
+      val event = eventJson.json
       val parameter = event.getJSONObject("parameters")
       val user = new User(parameter.getString("username"))
       val time = OffsetDateTime.parse(event.getString("created_at"), DATE_FORMATTER)
@@ -65,8 +68,9 @@ class TipeeestreamEventInputImpl extends EventInputImpl[TipeeestreamEvent, Tipee
     }
   }
 
-  private def onFollow(event: JSONObject): Unit = {
+  private def onFollow(eventJson: FollowEventJSON): Unit = {
     try {
+      val event = eventJson.json
       val parameter = event.getJSONObject("parameters")
       val user = new User(parameter.getString("username"))
       val time = OffsetDateTime.parse(event.getString("created_at"), DATE_FORMATTER)

--- a/src/main/scala/org/codeoverflow/chatoverflow/requirement/service/tipeeestream/impl/TipeeestreamEventInputImpl.scala
+++ b/src/main/scala/org/codeoverflow/chatoverflow/requirement/service/tipeeestream/impl/TipeeestreamEventInputImpl.scala
@@ -19,14 +19,10 @@ class TipeeestreamEventInputImpl extends EventInputImpl[TipeeestreamEvent, Tipee
   private val DATE_FORMATTER = new DateTimeFormatterBuilder()
     .parseCaseInsensitive().append(DateTimeFormatter.ISO_LOCAL_DATE_TIME).appendOffset("+HHMM", "Z").toFormatter
 
-  private val onFollowFn = onFollow _
-  private val onSubscriptionFn = onSubscription _
-  private val onDonationFn = onDonation _
-
   override def start(): Boolean = {
-    sourceConnector.get.addFollowEventListener(onFollowFn)
-    sourceConnector.get.addSubscriptionEventListener(onSubscriptionFn)
-    sourceConnector.get.addDonationEventListener(onDonationFn)
+    sourceConnector.get.registerEventHandler(onFollow _)
+    sourceConnector.get.registerEventHandler(onSubscription _)
+    sourceConnector.get.registerEventHandler(onDonation _)
     true
   }
 
@@ -88,9 +84,7 @@ class TipeeestreamEventInputImpl extends EventInputImpl[TipeeestreamEvent, Tipee
   }
 
   override def stop(): Boolean = {
-    sourceConnector.get.removeFollowEventListener(onFollowFn)
-    sourceConnector.get.removeSubscriptionEventListener(onSubscriptionFn)
-    sourceConnector.get.removeDonationEventListener(onDonationFn)
+    sourceConnector.get.unregisterAllEventListeners
     true
   }
 }

--- a/src/main/scala/org/codeoverflow/chatoverflow/requirement/service/twitch/chat/TwitchChatConnector.scala
+++ b/src/main/scala/org/codeoverflow/chatoverflow/requirement/service/twitch/chat/TwitchChatConnector.scala
@@ -1,9 +1,8 @@
 package org.codeoverflow.chatoverflow.requirement.service.twitch.chat
 
 import org.codeoverflow.chatoverflow.WithLogger
-import org.codeoverflow.chatoverflow.connector.Connector
+import org.codeoverflow.chatoverflow.connector.EventConnector
 import org.pircbotx.cap.EnableCapHandler
-import org.pircbotx.hooks.events.{MessageEvent, UnknownEvent}
 import org.pircbotx.{Configuration, PircBotX}
 
 import scala.collection.mutable.ListBuffer
@@ -13,7 +12,7 @@ import scala.collection.mutable.ListBuffer
   *
   * @param sourceIdentifier the name to the twitch account
   */
-class TwitchChatConnector(override val sourceIdentifier: String) extends Connector(sourceIdentifier) with WithLogger {
+class TwitchChatConnector(override val sourceIdentifier: String) extends EventConnector(sourceIdentifier) with WithLogger {
   private val twitchChatListener = new TwitchChatListener
   private val connectionListener = new TwitchChatConnectListener(onConnect)
   private val oauthKey = "oauth"
@@ -23,21 +22,7 @@ class TwitchChatConnector(override val sourceIdentifier: String) extends Connect
   private var status: Option[(Boolean, String)] = None
   private val channels = ListBuffer[String]()
 
-  def addMessageEventListener(listener: MessageEvent => Unit): Unit = {
-    twitchChatListener.addMessageEventListener(listener)
-  }
-
-  def addUnknownEventListener(listener: UnknownEvent => Unit): Unit = {
-    twitchChatListener.addUnknownEventListener(listener)
-  }
-
-  def removeMessageEventListener(listener: MessageEvent => Unit): Unit = {
-    twitchChatListener.removeMessageEventListener(listener)
-  }
-
-  def removeUnknownEventListener(listener: UnknownEvent => Unit): Unit = {
-    twitchChatListener.removeUnknownEventListener(listener)
-  }
+  twitchChatListener.registerEventHandler((event, ct) => call(event)(ct, ct)) // passes all events from the twitch chat to the in/outputs
 
   def joinChannel(channel: String): Unit = {
     bot.send().joinChannel(channel)

--- a/src/main/scala/org/codeoverflow/chatoverflow/requirement/service/twitch/chat/TwitchChatListener.scala
+++ b/src/main/scala/org/codeoverflow/chatoverflow/requirement/service/twitch/chat/TwitchChatListener.scala
@@ -1,27 +1,28 @@
 package org.codeoverflow.chatoverflow.requirement.service.twitch.chat
 
+import org.codeoverflow.chatoverflow.requirement.impl.EventManager
 import org.pircbotx.hooks.ListenerAdapter
 import org.pircbotx.hooks.events.{MessageEvent, UnknownEvent}
-
-import scala.collection.mutable.ListBuffer
 
 /**
   * The twitch chat listener class holds the handlers to react to messages using the IRC bot.
   */
-class TwitchChatListener extends ListenerAdapter {
+class TwitchChatListener extends ListenerAdapter with EventManager {
 
-  private val messageEventListener = ListBuffer[MessageEvent => Unit]()
-  private val unknownEventListener = ListBuffer[UnknownEvent => Unit]()
+//  private val messageEventListener = ListBuffer[MessageEvent => Unit]()
+//  private val unknownEventListener = ListBuffer[UnknownEvent => Unit]()
 
   override def onMessage(event: MessageEvent): Unit = {
-    messageEventListener.foreach(listener => listener(event))
+//    messageEventListener.foreach(listener => listener(event))
+    call(event)
   }
 
   override def onUnknown(event: UnknownEvent): Unit = {
-    unknownEventListener.foreach(listener => listener(event))
+    call(event)
+//    unknownEventListener.foreach(listener => listener(event))
   }
 
-  def addMessageEventListener(listener: MessageEvent => Unit): Unit = {
+/*  def addMessageEventListener(listener: MessageEvent => Unit): Unit = {
     messageEventListener += listener
   }
 
@@ -35,6 +36,6 @@ class TwitchChatListener extends ListenerAdapter {
 
   def removeUnknownEventListener(listener: UnknownEvent => Unit): Unit = {
     unknownEventListener -= listener
-  }
+  }*/
 
 }

--- a/src/main/scala/org/codeoverflow/chatoverflow/requirement/service/twitch/chat/TwitchChatListener.scala
+++ b/src/main/scala/org/codeoverflow/chatoverflow/requirement/service/twitch/chat/TwitchChatListener.scala
@@ -9,33 +9,11 @@ import org.pircbotx.hooks.events.{MessageEvent, UnknownEvent}
   */
 class TwitchChatListener extends ListenerAdapter with EventManager {
 
-//  private val messageEventListener = ListBuffer[MessageEvent => Unit]()
-//  private val unknownEventListener = ListBuffer[UnknownEvent => Unit]()
-
   override def onMessage(event: MessageEvent): Unit = {
-//    messageEventListener.foreach(listener => listener(event))
     call(event)
   }
 
   override def onUnknown(event: UnknownEvent): Unit = {
     call(event)
-//    unknownEventListener.foreach(listener => listener(event))
   }
-
-/*  def addMessageEventListener(listener: MessageEvent => Unit): Unit = {
-    messageEventListener += listener
-  }
-
-  def addUnknownEventListener(listener: UnknownEvent => Unit): Unit = {
-    unknownEventListener += listener
-  }
-
-  def removeMessageEventListener(listener: MessageEvent => Unit): Unit = {
-    messageEventListener -= listener
-  }
-
-  def removeUnknownEventListener(listener: UnknownEvent => Unit): Unit = {
-    unknownEventListener -= listener
-  }*/
-
 }

--- a/src/main/scala/org/codeoverflow/chatoverflow/requirement/service/twitch/chat/impl/TwitchChatInputImpl.scala
+++ b/src/main/scala/org/codeoverflow/chatoverflow/requirement/service/twitch/chat/impl/TwitchChatInputImpl.scala
@@ -32,12 +32,9 @@ class TwitchChatInputImpl extends EventInputImpl[TwitchEvent, chat.TwitchChatCon
   private var currentChannel: Option[String] = None
   private var ignoreOwnMessages = false
 
-  private val onMessageFn = onMessage _
-  private val onUnknownFn = onUnknown _
-
   override def start(): Boolean = {
-    sourceConnector.get.addMessageEventListener(onMessageFn)
-    sourceConnector.get.addUnknownEventListener(onUnknownFn)
+    sourceConnector.get.registerEventHandler(onMessage _)
+    sourceConnector.get.registerEventHandler(onUnknown _)
     true
   }
 
@@ -116,8 +113,7 @@ class TwitchChatInputImpl extends EventInputImpl[TwitchEvent, chat.TwitchChatCon
     * @return true if stopping was successful
     */
   override def stop(): Boolean = {
-    sourceConnector.get.removeMessageEventListener(onMessageFn)
-    sourceConnector.get.removeUnknownEventListener(onUnknownFn)
+    sourceConnector.get.unregisterAllEventListeners
     true
   }
 }


### PR DESCRIPTION
Adds a EventConnector as described in #110.

For code reuse between the `EventInputImpl` and the `EventConnector` I added a general class for handling events called `EventManager`. 
While doing that I found out that it can also be used to reduce boilerplate in the `DiscordChatListener`, the `TipeeestreamListener` and the `TwitchChatListener`.