### PR TITLE
Package the build code in a jar instead of source code in plugin dev deployments

### DIFF
--- a/.idea/runConfigurations/Package_build_code__sbt_buildProject_package_.xml
+++ b/.idea/runConfigurations/Package_build_code__sbt_buildProject_package_.xml
@@ -1,0 +1,19 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Package build code (sbt buildProject/package)" type="SbtRunConfiguration" factoryName="sbt Task">
+    <!-- for IntelliJ < 2019.2-->
+    <setting name="tasks" value="buildProject/package" />
+    <setting name="vmparams" value="-Xms512M -Xmx1024M -Xss1M -XX:+CMSClassUnloadingEnabled" />
+    <setting name="workingDir" value="$PROJECT_DIR$" />
+
+    <!-- for IntelliJ >= 2019.2 -->
+    <option name="allowRunningInParallel" value="false" />
+    <option name="tasks" value="buildProject/package" />
+    <option name="useSbtShell" value="false" />
+    <option name="vmparams" value="-Xms512M -Xmx1024M -Xss1M -XX:+CMSClassUnloadingEnabled" />
+    <option name="workingDir" value="$PROJECT_DIR$" />
+
+    <!-- used by all IntelliJ versions -->
+    <envs />
+    <method />
+  </configuration>
+</component>

--- a/.idea/runConfigurations/_DeployDev__Generate_Bootstrap_Launcher_and_deploy_plugin_dev_environment.xml
+++ b/.idea/runConfigurations/_DeployDev__Generate_Bootstrap_Launcher_and_deploy_plugin_dev_environment.xml
@@ -7,6 +7,7 @@
       <option name="Make" enabled="true" />
       <option name="RunConfigurationTask" enabled="true" run_configuration_name="Build GUI (sbt gui)" run_configuration_type="SbtRunConfiguration" />
       <option name="RunConfigurationTask" enabled="true" run_configuration_name="Package and copy plugins (sbt package copy)" run_configuration_type="SbtRunConfiguration" />
+      <option name="RunConfigurationTask" enabled="true" run_configuration_name="Package build code (sbt buildProject/package)" run_configuration_type="SbtRunConfiguration" />
       <option name="RunConfigurationTask" enabled="true" run_configuration_name="Deploy dev (sbt deployDev)" run_configuration_type="SbtRunConfiguration" />
     </method>
   </configuration>

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ bootstrap_deploy_dev:
 	sbt clean
 	sbt gui
 	sbt package copy
+	sbt buildProject/package
 	sbt deployDev
 
 create:

--- a/build/build.sbt
+++ b/build/build.sbt
@@ -1,4 +1,5 @@
 name := "chatoverflow-build"
+version := "0.3"
 sbtPlugin := true
 
 // JSON lib (Jackson) used for parsing the GUI version in the package.json file

--- a/deployment-files/plugin-dev/project/build.properties
+++ b/deployment-files/plugin-dev/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.1.2

--- a/deployment-files/plugin-dev/project/dependencies.sbt
+++ b/deployment-files/plugin-dev/project/dependencies.sbt
@@ -1,0 +1,1 @@
+Compile / unmanagedJars := (file("./bin") ** "chatoverflow-build*.jar").classpath


### PR DESCRIPTION
Packages the build code in a jar instead of source code if deployed for plugin developers.
This way plugin devs also don't have to build the code for the tasks and so on which also saves some compile time if the sbt caches were cleared by running the advanced build or on the first run.