### PR TITLE
Fix the support for plugin dependencies inside the plugin dev environment

### DIFF
--- a/build/src/main/scala/org/codeoverflow/chatoverflow/build/deployment/BootstrapUtility.scala
+++ b/build/src/main/scala/org/codeoverflow/chatoverflow/build/deployment/BootstrapUtility.scala
@@ -114,7 +114,7 @@ object BootstrapUtility {
 
       // Second step: Create bin directories and copy all binaries
       val targetJarDirectories = List("bin", "deploy/bin")
-      prepareBinDirectories(logger, targetJarDirectories, scalaLibraryVersion, copyApi = true, copyBuild = false)
+      prepareBinDirectories(logger, targetJarDirectories, scalaLibraryVersion, copyApi = true)
 
       // Third step: Copy bootstrap launcher
       copyJars(s"bootstrap/target/scala-$scalaLibraryVersion/", List("deploy/"), logger)
@@ -152,9 +152,13 @@ object BootstrapUtility {
       // First step: Create directory
       createOrEmptyFolder("deployDev/")
 
-      // Second step: Copy all binaries
+      // Second step: Copy framework, GUI and build-code jars
       val targetJarDirectories = List("bin", "deployDev/bin")
-      prepareBinDirectories(logger, targetJarDirectories, scalaLibraryVersion, copyApi = false, copyBuild = true)
+      prepareBinDirectories(logger, targetJarDirectories, scalaLibraryVersion, copyApi = false)
+
+      createOrEmptyFolder("deployDev/project/lib")
+      val buildCodeTargetDirectories = List("bin", "deployDev/project/lib")
+      copyJars(s"build/target/scala-$scalaLibraryVersion/sbt-1.0", buildCodeTargetDirectories, logger)
 
       // Third step: Copy the api
       sbt.IO.copyDirectory(new File(apiProjectPath), new File("deployDev/api/"))
@@ -175,7 +179,7 @@ object BootstrapUtility {
     }
   }
 
-  private def prepareBinDirectories(logger: ManagedLogger, targetDirs: List[String], scalaLibraryVersion: String, copyApi: Boolean, copyBuild: Boolean): Unit = {
+  private def prepareBinDirectories(logger: ManagedLogger, targetDirs: List[String], scalaLibraryVersion: String, copyApi: Boolean): Unit = {
     // First prepare all bin folders
     targetDirs.foreach(d => {
       logger info s"Preparing '$d' folder."
@@ -187,8 +191,7 @@ object BootstrapUtility {
 
     val sourceJarDirectories = List(
       Some(s"target/scala-$scalaLibraryVersion/"),
-      if (copyApi) Some(s"api/target/scala-$scalaLibraryVersion/") else None,
-      if (copyBuild) Some(s"build/target/scala-$scalaLibraryVersion/sbt-1.0") else None
+      if (copyApi) Some(s"api/target/scala-$scalaLibraryVersion/") else None
     ).flatten
 
     sourceJarDirectories.foreach(d => copyJars(d, targetDirs, logger))

--- a/deployment-files/plugin-dev/build.sbt
+++ b/deployment-files/plugin-dev/build.sbt
@@ -46,3 +46,5 @@ create := new PluginCreateWizard(streams.value.log).createPluginTask(pluginFolde
 fetch := new PluginUtility(streams.value.log).fetchPluginsTask(pluginFolderNames.value, pluginBuildFileName.value,
   pluginTargetFolderNames.value, apiProjectPath.value)
 copy := new PluginUtility(streams.value.log).copyPluginsTask(pluginFolderNames.value, pluginTargetFolderNames.value, scalaMajorVersion)
+
+packageBin / includePom := false

--- a/deployment-files/plugin-dev/project/dependencies.sbt
+++ b/deployment-files/plugin-dev/project/dependencies.sbt
@@ -1,1 +1,0 @@
-Compile / unmanagedJars := (file("./bin") ** "chatoverflow-meta-build*.jar").classpath


### PR DESCRIPTION
The `PomInclusionPlugin` added in #113 didn't work in the plugin developer environment because sbt seems to only check the `unmanagedBase` for auto-plugins, not `unmanagedJars` that was used to load the build jar.

This PR moves the jar of the build code in the plugin dev environment from `bin/chatoverflow-meta-build-*.jar` to `project/lib/chatoverflow-meta-build-*.jar`.

By this the jar is in the `unmanagedBase` directory and sbt loads the `PomInclusionPlugin` and the dependency support for plugins is fixed in the plugin dev environment.